### PR TITLE
additional brightscript navigation features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1517,6 +1517,11 @@
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
+        "hoek": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+            "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+        },
         "htmlparser2": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
@@ -1539,6 +1544,14 @@
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ieee754": {
@@ -5964,6 +5977,11 @@
             "version": "1.27.0",
             "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.27.0.tgz",
             "integrity": "sha512-cg3lKqVwxNpO2pLBxSwkBvE7w06+bHfbA/s14u8izSWyhJtPgRu1lQwi5tEyTRuwfEugfoPwerYL4vtY6teQDw=="
+        },
+        "vscode-uri": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+            "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
         },
         "vso-node-api": {
             "version": "6.1.2-preview",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
         "q": "^1.5.1",
         "roku-deploy": "^0.2.1",
         "vscode-debugadapter": "1.27.0",
-        "vscode-debugprotocol": "1.27.0"
+        "vscode-debugprotocol": "1.27.0",
+        "hoek": "^5.0.3",
+        "vscode-uri": "1.0.1",
+        "iconv-lite": "latest"
     },
     "devDependencies": {
         "@types/chai": "^4.1.5",
@@ -267,7 +270,14 @@
                     "scope": "resource"
                 }
             }
-        }
+        },
+        "commands": [
+            {
+                "command": "extension.brightscript.toggleXML",
+                "title": "Toggle xml/brs",
+                "category": "Brightscript"
+            }
+        ]
     },
     "watch": {
         "test": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "vscode-debugprotocol": "1.27.0",
         "hoek": "^5.0.3",
         "vscode-uri": "1.0.1",
-        "iconv-lite": "latest"
+        "iconv-lite": "0.4.24"
     },
     "devDependencies": {
         "@types/chai": "^4.1.5",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+
+export function registerCommands({ subscriptions }: vscode.ExtensionContext) {
+
+    async function openFile(filename: string) {
+        let uri = vscode.Uri.file(filename);
+        let doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
+        await vscode.window.showTextDocument(doc, {preview: false});
+    }
+
+    // register a command that opens a cowsay-document
+  subscriptions.push(vscode.commands.registerCommand('extension.brightscript.toggleXML', async () => {
+    if (vscode.window.activeTextEditor) {
+      const currentDocument = vscode.window.activeTextEditor.document;
+      if (currentDocument !== undefined && currentDocument.fileName.toLowerCase().endsWith(".brs")){
+        //jump to xml file
+        openFile(currentDocument.fileName.substring(0, currentDocument.fileName.length - 4) + ".xml");
+      } else if (currentDocument !== undefined && currentDocument.fileName.toLowerCase().endsWith(".xml")){
+        //jump to brs file
+        openFile(currentDocument.fileName.substring(0, currentDocument.fileName.length - 4) + ".brs");
+      }
+    }
+  }));
+}

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,0 +1,16 @@
+import { CompletionItem, CompletionItemKind } from "vscode";
+
+const Command = CompletionItemKind.Function;
+
+export const BuiltinComplationItems: CompletionItem[] = [
+  //WIP - can do way better than this!
+  {
+    label: "print",
+
+    kind: Command,
+  },
+  {
+    label: "createObject",
+    kind: Command,
+  },
+];

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -1,0 +1,257 @@
+import * as fs from "fs";
+import * as iconv from "iconv-lite";
+import * as vscode from "vscode";
+
+import { Disposable, Event, EventEmitter, Position, Range, SymbolInformation, SymbolKind, Uri } from "vscode";
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////
+// CREDIT WHERE CREDIT IS DUE
+// georgejecook: I lifted most of the declration and symbol work from sasami's era basic implementation
+// at https://github.com/sasami/vscode-erabasic and hcked it in with some basic changes
+///////////////////////////////////////////////////////////////////////////////////////////////////////////
+export class Declaration {
+  constructor(
+    public name: string,
+    public kind: SymbolKind,
+    public container: Declaration | undefined,
+    public nameRange: Range,
+    public bodyRange: Range) {
+
+  }
+
+
+  get isGlobal(): boolean {
+    return this.container === undefined;
+  }
+
+  get containerName(): string | undefined {
+    return this.container && this.container.name;
+  }
+
+  public visible(position: Position): boolean {
+    return this.container === undefined || this.container.bodyRange.contains(position);
+  }
+}
+
+function* iterlines(input: string): IterableIterator<[number, string]> {
+  const lines = input.split(/\r?\n/);
+  loop: for (let i = 0; i < lines.length; i++) {
+    const text = lines[i];
+    if (/^\s*(?:$|;(?![!#];))/.test(text)) {
+      continue;
+    }
+    yield [i, text];
+  }
+}
+
+export function readDeclarations(input: string): Declaration[] {
+  const symbols: Declaration[] = [];
+  let currentFunction: Declaration;
+  let funcEndLine: number;
+  let funcEndChar: number;
+  let mDefs = {};
+  console.log("READ DECLARATIONS");
+  for (const [line, text] of iterlines(input)) {
+    // console.log("" + line + ": " + text);
+    funcEndLine = line;
+    funcEndChar = text.length;
+
+    //FUNCTION START
+    let match = /^(?:function|sub)\s+(.*[^\(])\(/i.exec(text);
+    console.log("match " + match);
+    if (match !== null) {
+      console.log("function START");
+      // function has started
+      if (currentFunction !== undefined) {
+        currentFunction.bodyRange = currentFunction.bodyRange.with({ end: new Position(funcEndLine, funcEndChar) });
+      }
+      currentFunction = new Declaration(
+        match[1],
+        SymbolKind.Function,
+        undefined,
+        new Range(line, match[0].length - match[1].length -1, line, match[0].length -1),
+        new Range(line, 0, line, text.length),
+      );
+      console.log("function START", currentFunction.name);
+      symbols.push(currentFunction);
+      continue;
+    }
+
+    //FUNCTION END
+    match = /^\s*(end)\s*(function|sub)/i.exec(text);
+    if (match !== null) {
+      console.log("function END");
+      if (currentFunction !== undefined) {
+        currentFunction.bodyRange = currentFunction.bodyRange.with({ end: new Position(funcEndLine, funcEndChar) });
+      }
+      continue;
+    }
+
+    // //VAR
+    match = /^\s*(?:m\.)([a-zA-Z_0-9]*)/i.exec(text);
+    if (match !== null) {
+      // console.log("FOUND VAR " + match);
+      const name = match[1].trim();
+      if (mDefs[name] !== true) {
+        mDefs[name] = true;
+        let varSymbol = new Declaration(
+          name,
+          SymbolKind.Field,
+          undefined,
+          new Range(line, match[0].length - match[1].length, line, match[0].length),
+          new Range(line, 0, line, text.length),
+        );
+        console.log("FOUND VAR " + varSymbol.name);
+        symbols.push(varSymbol);
+      }
+      continue;
+    }
+  }
+  return symbols;
+}
+
+class WorkspaceEncoding {
+  private encoding: string[][];
+
+  constructor() {
+    this.reset();
+  }
+
+  public find(path: string): string {
+    return this.encoding.find((v) => path.startsWith(v[0]))[1];
+  }
+
+  public reset() {
+    this.encoding = [];
+    for (const folder of vscode.workspace.workspaceFolders) {
+      this.encoding.push([folder.uri.fsPath, this.getConfiguration(folder.uri)]);
+    }
+  }
+
+  private getConfiguration(uri: Uri): string {
+    const encoding: string = vscode.workspace.getConfiguration("files", uri).get("encoding", "utf8");
+    if (encoding === "utf8bom") {
+      return "utf8";  // iconv-lite removes bom by default when decoding, so this is fine
+    }
+    return encoding;
+  }
+}
+
+export class DeclarationChangeEvent {
+  constructor(public uri: Uri, public decls: Declaration[]) {
+  }
+}
+
+export class DeclarationDeleteEvent {
+  constructor(public uri: Uri) {
+  }
+}
+
+export class DeclarationProvider implements Disposable {
+  private fullscan: boolean = true;
+
+  private dirty: Map<string, Uri> = new Map();
+
+  private syncing: Promise<void>;
+  private encoding: WorkspaceEncoding = new WorkspaceEncoding();
+
+  private disposable: Disposable;
+
+  private onDidChangeEmitter: EventEmitter<DeclarationChangeEvent> = new EventEmitter();
+  private onDidDeleteEmitter: EventEmitter<DeclarationDeleteEvent> = new EventEmitter();
+  private onDidResetEmitter: EventEmitter<void> = new EventEmitter();
+
+  constructor() {
+    const subscriptions: Disposable[] = [];
+
+    const watcher = vscode.workspace.createFileSystemWatcher("**/*.brs");
+    watcher.onDidCreate(this.onDidChangeFile, this);
+    watcher.onDidChange(this.onDidChangeFile, this);
+    watcher.onDidDelete(this.onDidDeleteFile, this);
+    subscriptions.push(watcher);
+
+    vscode.workspace.onDidChangeConfiguration(this.onDidChangeWorkspace, this, subscriptions);
+    vscode.workspace.onDidChangeWorkspaceFolders(this.onDidChangeWorkspace, this, subscriptions);
+
+    this.disposable = Disposable.from(...subscriptions);
+  }
+
+  get onDidChange(): Event<DeclarationChangeEvent> {
+    return this.onDidChangeEmitter.event;
+  }
+
+  get onDidDelete(): Event<DeclarationDeleteEvent> {
+    return this.onDidDeleteEmitter.event;
+  }
+
+  get onDidReset(): Event<void> {
+    return this.onDidResetEmitter.event;
+  }
+
+  public sync(): Promise<void> {
+    console.log("syncing 11");
+    if (this.syncing === undefined) {
+      this.syncing = this.flush().then(() => {
+        this.syncing = undefined;
+      });
+    }
+    return this.syncing;
+  }
+
+  public dispose() {
+    this.disposable.dispose();
+  }
+
+  private onDidChangeFile(uri: Uri) {
+    console.log("onDidChangeFile 11");
+    this.dirty.set(uri.fsPath, uri);
+  }
+
+  private onDidDeleteFile(uri: Uri) {
+    this.dirty.delete(uri.fsPath);
+    this.onDidDeleteEmitter.fire(new DeclarationDeleteEvent(uri));
+  }
+
+  private onDidChangeWorkspace() {
+    console.log("onDidChangeWorkspace 33");
+    this.fullscan = true;
+    this.dirty.clear();
+    this.encoding.reset();
+    this.onDidResetEmitter.fire();
+  }
+
+  private async flush(): Promise<void> {
+    if (this.fullscan) {
+      this.fullscan = false;
+      for (const uri of await vscode.workspace.findFiles("**/*.brs")) {
+        this.dirty.set(uri.fsPath, uri);
+      }
+    }
+    if (this.dirty.size === 0) {
+      return;
+    }
+    for (const [path, uri] of Array.from(this.dirty)) {
+      const input = await new Promise<string>((resolve, reject) => {
+        fs.readFile(path, (err, data) => {
+          if (err) {
+            if (typeof err === "object" && err.code === "ENOENT") {
+              resolve();
+            } else {
+              reject(err);
+            }
+          } else {
+            resolve(iconv.decode(data, this.encoding.find(path)));
+          }
+        });
+      });
+      if (input === undefined) {
+        this.dirty.delete(path);
+        this.onDidDeleteEmitter.fire(new DeclarationDeleteEvent(uri));
+        continue;
+      }
+      if (this.dirty.delete(path)) {
+        this.onDidChangeEmitter.fire(new DeclarationChangeEvent(uri, readDeclarations(input)));
+      }
+    }
+  }
+}

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -35,7 +35,7 @@ export class Declaration {
 
 function* iterlines(input: string): IterableIterator<[number, string]> {
   const lines = input.split(/\r?\n/);
-  loop: for (let i = 0; i < lines.length; i++) {
+  for (let i = 0; i < lines.length; i++) {
     const text = lines[i];
     if (/^\s*(?:$|;(?![!#];))/.test(text)) {
       continue;

--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -1,0 +1,94 @@
+import * as vscode from "vscode";
+
+import { Location, Position, TextDocument, Uri } from "vscode";
+
+import { Declaration, DeclarationProvider, readDeclarations } from "./declaration";
+
+function declToDefinition(uri: Uri, decl: Declaration): Location {
+  return new Location(uri, decl.nameRange);
+}
+
+class DefinitionInfo {
+  constructor(public name: string, public location: Location) {
+  }
+}
+
+export class DefinitionRepository {
+  private cache: Map<string, DefinitionInfo[]> = new Map();
+
+  constructor(private provider: DeclarationProvider) {
+    provider.onDidChange((e) => {
+      this.cache.set(e.uri.fsPath, e.decls.filter((d) => d.isGlobal)
+        .map((d) => new DefinitionInfo(d.name, declToDefinition(e.uri, d))));
+    });
+    provider.onDidDelete((e) => {
+      this.cache.delete(e.uri.fsPath);
+    });
+    provider.onDidReset((e) => {
+      this.cache.clear();
+    });
+  }
+
+  public sync(): Promise<void> {
+    return this.provider.sync();
+  }
+
+  public *find(document: TextDocument, position: Position): IterableIterator<Location> {
+    const word = this.getWord(document, position).toLowerCase(); //brightscript is not case sensitive!
+    console.log("find word" + word);
+    this.sync();
+    if (word === undefined) {
+      return;
+    }
+    yield* this.findInCurrentDocument(document, position, word);
+    const ws = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (ws === undefined) {
+      return;
+    }
+    const fresh: Set<string> = new Set([document.uri.fsPath]);
+    for (const doc of vscode.workspace.textDocuments) {
+      if (!doc.isDirty) {
+        continue;
+      }
+      if (doc === document) {
+        continue;
+      }
+      if (!this.cache.has(doc.uri.fsPath)) {
+        continue;
+      }
+      if (!doc.uri.fsPath.startsWith(ws.uri.fsPath)) {
+        continue;
+      }
+      fresh.add(doc.uri.fsPath);
+      yield* this.findInDocument(doc, word);
+    }
+    for (const [path, defs] of this.cache.entries()) {
+      if (fresh.has(path)) {
+        continue;
+      }
+      if (!path.startsWith(ws.uri.fsPath)) {
+        continue;
+      }
+      yield* defs.filter((d) => d.name.toLowerCase() === word).map((d) => d.location);
+    }
+  }
+
+  private getWord(document: TextDocument, position: Position): string {
+    const range = document.getWordRangeAtPosition(position, /[^\s\x21-\x2f\x3a-\x40\x5b-\x5e\x7b-\x7e]+/);
+    if (range !== undefined) {
+      return document.getText(range);
+    }
+  }
+
+  private findInCurrentDocument(document: TextDocument, position: Position, word: string): Location[] {
+    return readDeclarations(document.getText())
+      .filter((d) => d.name.toLowerCase() === word && d.visible(position))
+      .map((d) => declToDefinition(document.uri, d));
+  }
+
+  private findInDocument(document: TextDocument, word: string): Location[] {
+    return readDeclarations(document.getText())
+      .filter((d) => d.name.toLowerCase() === word && d.isGlobal)
+      .map((d) => declToDefinition(document.uri, d));
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,20 +1,41 @@
 import * as vscode from 'vscode';
 import { Formatter } from './formatter';
-import { WorkspaceFolder, DebugConfiguration, CancellationToken, ProviderResult } from 'vscode';
+import {
+  WorkspaceFolder, DebugConfiguration, CancellationToken, ProviderResult,
+  CompletionItem, CompletionItemProvider,
+  Definition,
+  DefinitionProvider, DocumentSelector,
+  DocumentSymbolProvider,
+  ExtensionContext,
+  Position, SymbolInformation,
+  TextDocument, WorkspaceSymbolProvider
+} from 'vscode';
+
+import { BuiltinComplationItems } from "./completion";
+import { DefinitionRepository } from "./definitionProvider";
+import { DeclarationProvider } from "./declaration";
+import { readSymbolInformations, SymbolInformationRepository } from "./symbol";
+import { registerCommands } from './commands';
 
 export function activate(context: vscode.ExtensionContext) {
 	//register the code formatter
   vscode.languages.registerDocumentRangeFormattingEditProvider({ language: 'brightscript', scheme: 'file' }, new Formatter());
 
-	context.subscriptions.push(vscode.commands.registerCommand('extension.mock-debug.getProgramName', config => {
-		return vscode.window.showInputBox({
-			placeHolder: 'Please enter the name of a markdown file in the workspace folder',
-			value: 'readme.md'
-		});
-	}));
+  // const selector: DocumentSelector = { language: "Brightscript" };
+  const provider: DeclarationProvider = new DeclarationProvider();
+  const definitionProvider = new BrightscriptDefinitionProvider(provider);
+  const selector = { scheme: 'file', pattern: '**/*.{brs}' };
+  const registerDefinitionProvider = vscode.languages.registerDefinitionProvider(selector, definitionProvider);
+  context.subscriptions.push(registerDefinitionProvider);
 
+  // experimental placeholder
+  // context.subscriptions.push(vscode.languages.registerCompletionItemProvider(selector, new BrightscriptCompletionItemProvider()));
+  context.subscriptions.push(vscode.languages.registerDefinitionProvider(selector, new BrightscriptDefinitionProvider(provider)));
+  context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new BrightscriptDocumentSymbolProvider()));
+  context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new BrightscriptWorkspaceSymbolProvider(provider)));
+  context.subscriptions.push(provider);
 
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('brightscript', new BrightscriptConfigurationProvider()));
+  registerCommands(context);
 }
 
 class BrightscriptConfigurationProvider implements vscode.DebugConfigurationProvider {
@@ -22,54 +43,91 @@ class BrightscriptConfigurationProvider implements vscode.DebugConfigurationProv
 	 * Massage a debug configuration just before a debug session is being launched,
 	 * e.g. add all missing attributes to the debug configuration.
 	 */
-	async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: BrightscriptDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
-		//fill in default configuration values
-		if (config.type === 'brightscript') {
-			config.name = config.name ? config.name : 'BrightScript Debug: Launch';
-			config.consoleOutput = config.consoleOutput ? config.consoleOutput : 'normal';
-			config.request = config.request ? config.request : 'launch';
-			config.stopOnEntry = config.stopOnEntry === false ? false : true;
-			config.rootDir = config.rootDir ? config.rootDir : '${workspaceFolder}';
-			config.outDir = config.outDir ? config.outDir : '${workspaceFolder}/out';
-			config.retainDeploymentArchive = config.retainDeploymentArchive === false ? false : true;
-			config.retainStagingFolder = config.retainStagingFolder === true ? true : false;
-		}
-		//prompt for host if not hardcoded
-		if (config.host === '${promptForHost}') {
-			config.host = await vscode.window.showInputBox({
-				placeHolder: 'The IP address of your Roku device',
-				value: ''
-			});
-			if (!config.host) {
-				throw new Error('Debug session terminated: host is required.');
-			}
-		}
-		//prompt for password if not hardcoded
-		if (config.password === '${promptForPassword}') {
-			config.password = await vscode.window.showInputBox({
-				placeHolder: 'The developer account password for your Roku device.',
-				value: ''
-			});
-			if (!config.password) {
-				throw new Error('Debug session terminated: password is required.');
-			}
-		}
+  async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: BrightscriptDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
+    //fill in default configuration values
+    if (config.type === 'brightscript') {
+      config.name = config.name ? config.name : 'BrightScript Debug: Launch';
+      config.consoleOutput = config.consoleOutput ? config.consoleOutput : 'normal';
+      config.request = config.request ? config.request : 'launch';
+      config.stopOnEntry = config.stopOnEntry === false ? false : true;
+      config.rootDir = config.rootDir ? config.rootDir : '${workspaceFolder}';
+      config.outDir = config.outDir ? config.outDir : '${workspaceFolder}/out';
+      config.retainDeploymentArchive = config.retainDeploymentArchive === false ? false : true;
+      config.retainStagingFolder = config.retainStagingFolder === true ? true : false;
+    }
+    //prompt for host if not hardcoded
+    if (config.host === '${promptForHost}') {
+      config.host = await vscode.window.showInputBox({
+        placeHolder: 'The IP address of your Roku device',
+        value: ''
+      });
+      if (!config.host) {
+        throw new Error('Debug session terminated: host is required.');
+      }
+    }
+    //prompt for password if not hardcoded
+    if (config.password === '${promptForPassword}') {
+      config.password = await vscode.window.showInputBox({
+        placeHolder: 'The developer account password for your Roku device.',
+        value: ''
+      });
+      if (!config.password) {
+        throw new Error('Debug session terminated: password is required.');
+      }
+    }
 
-		//await vscode.window.showInformationMessage('Invalid Roku IP address')
-		return config;
-	}
+    //await vscode.window.showInformationMessage('Invalid Roku IP address')
+    return config;
+  }
 }
 
 export function deactivate() {
 }
 
 interface BrightscriptDebugConfiguration extends DebugConfiguration {
-	host: string;
-	password: string;
-	rootDir: string;
-	outDir: string;
-	stopOnEntry: boolean;
-	consoleOutput: 'full' | 'normal';
-	retainDeploymentArchive: boolean;
-	retainStagingFolder: boolean;
+  host: string;
+  password: string;
+  rootDir: string;
+  outDir: string;
+  stopOnEntry: boolean;
+  consoleOutput: 'full' | 'normal';
+  retainDeploymentArchive: boolean;
+  retainStagingFolder: boolean;
+}
+
+class BrightscriptDefinitionProvider implements DefinitionProvider {
+  private repo: DefinitionRepository;
+
+  constructor(provider: DeclarationProvider) {
+    this.repo = new DefinitionRepository(provider);
+  }
+
+  public provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Definition> {
+    return this.repo.sync().then(() => Array.from(this.repo.find(document, position)));
+  }
+}
+
+class BrightscriptDocumentSymbolProvider implements DocumentSymbolProvider {
+  public provideDocumentSymbols(document: TextDocument, token: CancellationToken): SymbolInformation[] {
+    return readSymbolInformations(document.uri, document.getText());
+  }
+}
+
+class BrightscriptWorkspaceSymbolProvider implements WorkspaceSymbolProvider {
+  private repo: SymbolInformationRepository;
+
+  constructor(provider: DeclarationProvider) {
+    this.repo = new SymbolInformationRepository(provider);
+  }
+
+  public provideWorkspaceSymbols(query: string, token: CancellationToken): Promise<SymbolInformation[]> {
+    return this.repo.sync().then(() => Array.from(this.repo.find(query)));
+  }
+}
+
+class BrightscriptCompletionItemProvider implements CompletionItemProvider {
+  public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: vscode.CompletionContext): CompletionItem[] {
+    //TODO - do something useful here!
+    return BuiltinComplationItems;
+  }
 }

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,0 +1,81 @@
+import * as vscode from "vscode";
+
+import { Location, SymbolInformation, TextDocument, Uri } from "vscode";
+
+import { Declaration, DeclarationProvider, readDeclarations } from "./declaration";
+
+function declToSymbolInformation(uri: Uri, decl: Declaration): SymbolInformation {
+  return new SymbolInformation(
+    decl.name,
+    decl.kind,
+    decl.containerName ? decl.containerName : decl.name,
+    new Location(uri, decl.bodyRange),
+  );
+}
+
+export function readSymbolInformations(uri: Uri, input: string): SymbolInformation[] {
+  return readDeclarations(input).map((d) => declToSymbolInformation(uri, d));
+}
+
+export class SymbolInformationRepository {
+  private cache: Map<string, SymbolInformation[]> = new Map();
+
+  constructor(private provider: DeclarationProvider) {
+    provider.onDidChange((e) => {
+      this.cache.set(e.uri.fsPath, e.decls
+        .map((d) => declToSymbolInformation(e.uri, d)));
+    });
+    provider.onDidDelete((e) => {
+      this.cache.delete(e.uri.fsPath);
+    });
+    provider.onDidReset((e) => {
+      this.cache.clear();
+    });
+  }
+
+  public sync(): Promise<void> {
+    return this.provider.sync();
+  }
+
+  public *find(query: string): IterableIterator<SymbolInformation> {
+    const pattern = this.compileQuery(query);
+    if (pattern === undefined) {
+      return;
+    }
+    const fresh: Set<string> = new Set();
+    for (const doc of vscode.workspace.textDocuments) {
+      if (!doc.isDirty) {
+        continue;
+      }
+      if (!this.cache.has(doc.uri.fsPath)) {
+        continue;
+      }
+      fresh.add(doc.uri.fsPath);
+      yield* this.findInDocument(doc, pattern);
+    }
+    for (const [path, symbols] of this.cache.entries()) {
+      if (fresh.has(path)) {
+        continue;
+      }
+      yield* symbols.filter((s) => pattern.test(s.name));
+    }
+  }
+
+  private compileQuery(query: string): RegExp | undefined {
+    if (query.length === 0) {
+      return;
+    }
+    const chars = Array.from(query).map((c) => {
+      const uc = c.toUpperCase();
+      const lc = c.toLowerCase();
+      return uc === lc ? c : `[${uc}${lc}]`;
+    });
+    return new RegExp(chars.join(".*"));
+  }
+
+  private findInDocument(document: TextDocument, pattern: RegExp): SymbolInformation[] {
+    return readDeclarations(document.getText())
+      .filter((d) => pattern.test(d.name))
+      .map((d) => declToSymbolInformation(document.uri, d));
+  }
+}

--- a/src/symbolProvider.ts
+++ b/src/symbolProvider.ts
@@ -1,0 +1,46 @@
+import * as vscode from 'vscode';
+
+export function getFnRegex(): RegExp {
+  let functionRegex = "^(?:function|sub)\\s+(.*[^\\(])\\(";
+  const regex = new RegExp(functionRegex, 'i');
+  return regex;
+}
+
+export function getSymbolForMatch(testFnMatch: RegExpMatchArray, document: vscode.TextDocument, line: number, kind: vscode.SymbolKind): vscode.SymbolInformation {
+  const container = testFnMatch[1];
+  const name = testFnMatch[1];
+  return new vscode.SymbolInformation(name, kind, container,
+    new vscode.Location(document.uri, new vscode.Position(line, 0)));
+}
+
+const functionRegexPattern = getFnRegex();
+
+export function getSymbolForLine(document: vscode.TextDocument, line: number): vscode.SymbolInformation | undefined {
+  const { text } = document.lineAt(line);
+  const functionMatch = text.match(functionRegexPattern);
+  if (functionMatch) {
+    return getSymbolForMatch(functionMatch, document, line, vscode.SymbolKind.Module);
+  }
+  return undefined;
+}
+
+const symbolProvider = {
+  provideDocumentSymbols(document: vscode.TextDocument): vscode.SymbolInformation[] {
+    const lineCount = Math.min(document.lineCount, 10000);
+    const result: vscode.SymbolInformation[] = [];
+    for (let line = 0; line < lineCount; line++) {
+      const symbol = getSymbolForLine(document, line);
+      if (symbol) {
+        console.log("got symbol " + symbol);
+        result.push(symbol);
+      }
+    }
+
+    return result;
+  }
+};
+
+
+export function addSymbolProvider(context: vscode.ExtensionContext) {
+  context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider('brightscript', symbolProvider));
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,55 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+const extensions = ['.js', '.ts', '.json', '.jsx', '.tsx', '.vue', '.css', '.mcss', '.scss', '.less', '.html'];
+
+async function readDir(dirPath: string) {
+  let result = await new Promise((resolve, reject) => {
+    fs.readdir(dirPath, (err, result) => {
+      if (err) { reject(err); }
+      resolve(result);
+    });
+  });
+  return <string[]>result;
+}
+async function stat(filePath: string) {
+  return await new Promise((resolve, reject) => {
+    fs.stat(filePath, (err, result) => {
+      if (err) { reject(err); }
+      resolve(result);
+    });
+  });
+}
+
+export async function fixFilePathExtension(filePath: string) {
+  const dirPath = path.join(filePath, '../');
+  const fileName = filePath.replace(dirPath, '');
+
+  // with extension, return directly
+  if (fileName.indexOf('.') > 0) { return filePath; }
+
+  async function traverse(dirPath: string, fileName: string) {
+    let dir = await readDir(dirPath);
+    for (let ext of extensions) {
+      if (dir.indexOf(fileName + ext) > -1) {
+        return path.join(dirPath, fileName + ext);
+      }
+    }
+    if (dir.indexOf(fileName) !== -1) {
+      let stats = await stat(path.join(dirPath, fileName)) as fs.Stats;
+      if (stats.isFile()) {
+        return path.join(dirPath, fileName);
+      } else if (stats.isDirectory()) {
+        return 'dir';
+      }
+    }
+    return null;
+  }
+  // Traverse the directory where the file is located, match the file name. Suffix
+  let filePathWithExt = await traverse(dirPath, fileName);
+  if (filePathWithExt === 'dir') {
+    filePathWithExt = await traverse(filePath, 'index');
+  }
+  if (filePathWithExt && filePathWithExt !== 'dir') { return filePathWithExt; }
+  return null;
+}


### PR DESCRIPTION
Hi, here's a preliminary PR so you can try out the language features for yourself.

- adds declarations and symbols
- adds go to definition support
- adds command to jump between xml and brs files
- adds placeholder for completion

Please note - I formatted extension.ts (by accident); but I figured  I'll leave it as is, as it's more consistent : I can back it out if needs be.

Fire it up, press APPLE+SHIFT+O, to view symbols in file APPLE-T for whole project, and F12 to go to defintion.
Also find command to switch between xml and brs files - you can assign a hotkey to Brightscript: Toggle xml/brs
