### PR TITLE
better compile error messages WIP/sketch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,13 @@
         "out": false,
         "node_modules": false,
         ".nyc_output": true,
+        "**/.nyc_output": true,
+        ".nyc_output/**": true,
         ".roku-deploy-staging": false,
         "coverage": true,
         "**/node_modules": true,
-        "**/out": true
+        "**/out": true,
+        "node_modules/**": true,
+        "out/**": true
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,9 +382,9 @@
             }
         },
         "brightscript-formatter": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/brightscript-formatter/-/brightscript-formatter-1.3.0.tgz",
-            "integrity": "sha512-eo6JyGuy2FutDHHRYvWHmUdA7uoSaW0GHUz14y86LyAMcoyFpx4/o3ZiPMSXqhQUezRkY8kKtNmlYjwAIIL3bQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/brightscript-formatter/-/brightscript-formatter-1.4.0.tgz",
+            "integrity": "sha512-h6yVI5L7/9T2X2PRsDyvpXDijBUaUUEhdu0cNoygWuoqA8gq7u2L+bf9/r+BvnEygaU/K/i8GRo4cWkqfQCoJw==",
             "requires": {
                 "brightscript-parser": "1.1.0",
                 "trim-right": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -38,20 +38,20 @@
     },
     "dependencies": {
         "@types/glob": "^5.0.36",
-        "brightscript-formatter": "^1.3.0",
+        "brightscript-formatter": "^1.4.0",
         "eol": "^0.9.1",
         "find-in-files": "^0.4.0",
         "fs-extra": "^4.0.3",
         "glob": "^7.1.3",
+        "hoek": "^5.0.3",
+        "iconv-lite": "0.4.24",
         "net": "^1.0.2",
         "path": "^0.12.7",
         "q": "^1.5.1",
         "roku-deploy": "^0.2.1",
         "vscode-debugadapter": "1.27.0",
         "vscode-debugprotocol": "1.27.0",
-        "hoek": "^5.0.3",
-        "vscode-uri": "1.0.1",
-        "iconv-lite": "0.4.24"
+        "vscode-uri": "1.0.1"
     },
     "devDependencies": {
         "@types/chai": "^4.1.5",

--- a/src/BrightScriptFormatter.ts
+++ b/src/BrightScriptFormatter.ts
@@ -1,0 +1,448 @@
+import {
+    BrightScriptLexer,
+    CompositeKeywordTokenTypes,
+    KeywordTokenTypes,
+    Token,
+    TokenType
+} from 'brightscript-parser';
+import * as trimRight from 'trim-right';
+
+export class BrightScriptFormatter {
+    constructor() { }
+    /**
+     * The default number of spaces when indenting with spaces
+     */
+    private static DEFAULT_INDENT_SPACE_COUNT = 4;
+    /**
+     * Format the given input.
+     * @param inputText the text to format
+     * @param formattingOptions options specifying formatting preferences
+     */
+    public format(inputText: string, formattingOptions?: FormattingOptions) {
+        let options = this.normalizeOptions(formattingOptions);
+        let lexer = new BrightScriptLexer();
+        let tokens = lexer.tokenize(inputText);
+
+        //force all composite keywords to have 0 or 1 spaces in between, but no more than 1
+        tokens = this.normalizeCompositeKeywords(tokens);
+
+        if (options.compositeKeywords) {
+            tokens = this.formatCompositeKeywords(tokens, options);
+        }
+
+        if (options.indentStyle) {
+            tokens = this.formatIndentation(tokens, options);
+        }
+
+        if (options.keywordCase) {
+            tokens = this.formatKeywordCasing(tokens, options);
+        }
+        if (options.removeTrailingWhiteSpace) {
+            tokens = this.formatTrailingWhiteSpace(tokens, options);
+        }
+
+        //join all tokens back together into a single string
+        let outputText = '';
+        for (let token of tokens) {
+            outputText += token.value;
+        }
+        return outputText;
+    }
+
+    /**
+     * Remove all whitespace in the composite keyword tokens with a single space
+     * @param tokens
+     */
+    private normalizeCompositeKeywords(tokens: Token[]) {
+        let indexOffset = 0;
+        for (let token of tokens) {
+            token.startIndex += indexOffset;
+            //is this a composite token
+            if (CompositeKeywordTokenTypes.indexOf(token.tokenType) > -1) {
+                let value = token.value;
+                //remove all whitespace with a single space
+                token.value.replace(/s+/g, ' ');
+                let indexDifference = value.length - token.value.length;
+                indexOffset -= indexDifference;
+            }
+        }
+        return tokens;
+    }
+
+    private formatCompositeKeywords(tokens: Token[], options: FormattingOptions) {
+        let indexOffset = 0;
+        for (let token of tokens) {
+            token.startIndex += indexOffset;
+            //is this a composite token
+            if (CompositeKeywordTokenTypes.indexOf(token.tokenType) > -1) {
+                let parts = this.getCompositeKeywordParts(token);
+                let tokenValue = token.value;
+                if (options.compositeKeywords === 'combine') {
+                    token.value = parts[0] + parts[1];
+                } else {
+                    // if(options.compositeKeywords === 'split'){
+                    token.value = parts[0] + ' ' + parts[1];
+                }
+                let offsetDifference = token.value.length - tokenValue.length;
+                indexOffset += offsetDifference;
+            }
+        }
+        return tokens;
+    }
+
+    private getCompositeKeywordParts(token: Token) {
+        let lowerValue = token.value.toLowerCase();
+        //split the parts of the token, but retain their case
+        if (lowerValue.indexOf('end') === 0) {
+            return [token.value.substring(0, 3), token.value.substring(3).trim()];
+        } else if (lowerValue.indexOf('#else') === 0) {
+            return [token.value.substring(0, 5), token.value.substring(5).trim()];
+        } else {
+            // if (lowerValue.indexOf('exit') === 0 || lowerValue.indexOf('else') === 0) {
+            return [token.value.substring(0, 4), token.value.substring(4).trim()];
+        }
+    }
+
+    private formatKeywordCasing(tokens: Token[], options: FormattingOptions) {
+        for (let token of tokens) {
+            //if this token is a keyword
+            if (KeywordTokenTypes.indexOf(token.tokenType) > -1) {
+                switch (options.keywordCase) {
+                    case 'lower':
+                        token.value = token.value.toLowerCase();
+                        break;
+                    case 'upper':
+                        token.value = token.value.toUpperCase();
+                        break;
+                    case 'title':
+                        let lowerValue = token.value.toLowerCase();
+                        if (CompositeKeywordTokenTypes.indexOf(token.tokenType) === -1) {
+                            token.value =
+                                token.value.substring(0, 1).toUpperCase() +
+                                token.value.substring(1).toLowerCase();
+                        } else {
+                            let spaceCharCount = (lowerValue.match(/\s+/) || []).length;
+                            let firstWordLength: number = 0;
+                            if (lowerValue.indexOf('end') === 0) {
+                                firstWordLength = 3;
+                            } else {
+                                //if (lowerValue.indexOf('exit') > -1 || lowerValue.indexOf('else') > -1)
+                                firstWordLength = 4;
+                            }
+                            token.value =
+                                //first character
+                                token.value.substring(0, 1).toUpperCase() +
+                                //rest of first word
+                                token.value.substring(1, firstWordLength).toLowerCase() +
+                                //add back the whitespace
+                                token.value.substring(
+                                    firstWordLength,
+                                    firstWordLength + spaceCharCount
+                                ) +
+                                //first character of second word
+                                token.value
+                                    .substring(
+                                        firstWordLength + spaceCharCount,
+                                        firstWordLength + spaceCharCount + 1
+                                    )
+                                    .toUpperCase() +
+                                //rest of second word
+                                token.value
+                                    .substring(firstWordLength + spaceCharCount + 1)
+                                    .toLowerCase();
+                        }
+                }
+            }
+        }
+        return tokens;
+    }
+
+    private formatIndentation(tokens: Token[], options: FormattingOptions) {
+        let indentTokens = [
+            TokenType.sub,
+            TokenType.for,
+            TokenType.function,
+            TokenType.if,
+            TokenType.openCurlyBraceSymbol,
+            TokenType.openSquareBraceSymbol,
+            TokenType.while,
+            TokenType.condIf
+        ];
+        let outdentTokens = [
+            TokenType.closeCurlyBraceSymbol,
+            TokenType.closeSquareBraceSymbol,
+            TokenType.endFunction,
+            TokenType.endIf,
+            TokenType.endSub,
+            TokenType.endWhile,
+            TokenType.endFor,
+            TokenType.next,
+            TokenType.condEndIf
+        ];
+        let interumTokens = [
+            TokenType.else,
+            TokenType.elseIf,
+            TokenType.condElse,
+            TokenType.condElseIf
+        ];
+        let tabCount = 0;
+
+        let nextLineStartTokenIndex = 0;
+        //the list of output tokens
+        let outputTokens: Token[] = [];
+        //set the loop to run for a max of double the number of tokens we found so we don't end up with an infinite loop
+        outer: for (
+            let outerLoopCounter = 0;
+            outerLoopCounter <= tokens.length * 2;
+            outerLoopCounter++
+        ) {
+            let lineObj = this.getLineTokens(nextLineStartTokenIndex, tokens);
+
+            nextLineStartTokenIndex = lineObj.stopIndex + 1;
+            let lineTokens = lineObj.tokens;
+            let thisTabCount = tabCount;
+            let foundIndentorThisLine = false;
+
+            //if this is a single-line if statement, do nothing with indentation
+            if (this.isSingleLineIfStatement(lineTokens, tokens)) {
+                // //if this line has a return statement, outdent
+                // if (this.tokenIndexOf(TokenType.return, lineTokens) > -1) {
+                //     tabCount--;
+                // } else {
+                //     //do nothing with single-line if statement indentation
+                // }
+            } else {
+                for (let token of lineTokens) {
+                    //if this is an indentor token,
+                    if (indentTokens.indexOf(token.tokenType) > -1) {
+                        tabCount++;
+                        foundIndentorThisLine = true;
+
+                        //this is an outdentor token
+                    } else if (outdentTokens.indexOf(token.tokenType) > -1) {
+                        tabCount--;
+                        if (foundIndentorThisLine === false) {
+                            thisTabCount--;
+                        }
+
+                        //this is an interum token
+                    } else if (interumTokens.indexOf(token.tokenType) > -1) {
+                        //these need outdented, but don't change the tabCount
+                        thisTabCount--;
+                    }
+                    //  else if (token.tokenType === TokenType.return && foundIndentorThisLine) {
+                    //     //a return statement on the same line as an indentor means we don't want to indent
+                    //     tabCount--;
+                    // }
+                }
+            }
+            //if the tab counts are less than zero, something is wrong. However, at least try to do formatting as best we can by resetting to 0
+            thisTabCount = thisTabCount < 0 ? 0 : thisTabCount;
+            tabCount = tabCount < 0 ? 0 : tabCount;
+
+            let leadingWhitespace: string;
+
+            if (options.indentStyle === 'spaces') {
+                let indentSpaceCount = options.indentSpaceCount
+                    ? options.indentSpaceCount
+                    : BrightScriptFormatter.DEFAULT_INDENT_SPACE_COUNT;
+                let spaceCount = thisTabCount * indentSpaceCount;
+                leadingWhitespace = Array(spaceCount + 1).join(' ');
+            } else {
+                leadingWhitespace = Array(thisTabCount + 1).join('\t');
+            }
+            //create a whitespace token if there isn't one
+            if (lineTokens[0] && lineTokens[0].tokenType !== TokenType.whitespace) {
+                lineTokens.unshift({
+                    startIndex: -1,
+                    tokenType: TokenType.whitespace,
+                    value: ''
+                });
+            }
+
+            //replace the whitespace with the formatted whitespace
+            lineTokens[0].value = leadingWhitespace;
+
+            //add this list of tokens
+            outputTokens.push.apply(outputTokens, lineTokens);
+            //if we have found the end of file
+            if (
+                lineTokens[lineTokens.length - 1].tokenType === TokenType.END_OF_FILE
+            ) {
+                break outer;
+            }
+            /* istanbul ignore next */
+            if (outerLoopCounter === tokens.length * 2) {
+                throw new Error('Something went terribly wrong');
+            }
+        }
+        return outputTokens;
+    }
+
+    /**
+     * Remove all trailing whitespace
+     */
+    private formatTrailingWhiteSpace(
+        tokens: Token[],
+        options: FormattingOptions
+    ) {
+        let nextLineStartTokenIndex = 0;
+        //the list of output tokens
+        let outputTokens: Token[] = [];
+
+        //set the loop to run for a max of double the number of tokens we found so we don't end up with an infinite loop
+        for (
+            let outerLoopCounter = 0;
+            outerLoopCounter <= tokens.length * 2;
+            outerLoopCounter++
+        ) {
+            let lineObj = this.getLineTokens(nextLineStartTokenIndex, tokens);
+
+            nextLineStartTokenIndex = lineObj.stopIndex + 1;
+            let lineTokens = lineObj.tokens;
+            //the last token is newline or EOF, so the next-to-last token is where the trailing whitespace would reside
+            let potentialWhitespaceTokenIndex = lineTokens.length - 2;
+
+            let whitespaceTokenCandidate = lineTokens[potentialWhitespaceTokenIndex];
+            //if the final token is whitespace, throw it away
+            if (whitespaceTokenCandidate.tokenType === TokenType.whitespace) {
+                lineTokens.splice(potentialWhitespaceTokenIndex, 1);
+
+                //if the final token is a comment, trim the whitespace from the righthand side
+            } else if (
+                whitespaceTokenCandidate.tokenType === TokenType.quoteComment ||
+                whitespaceTokenCandidate.tokenType === TokenType.remComment
+            ) {
+                whitespaceTokenCandidate.value = trimRight(
+                    whitespaceTokenCandidate.value
+                );
+            }
+
+            //add this line to the output
+            outputTokens.push.apply(outputTokens, lineTokens);
+
+            //if we have found the end of file, quit the loop
+            if (
+                lineTokens[lineTokens.length - 1].tokenType === TokenType.END_OF_FILE
+            ) {
+                break;
+            }
+        }
+        return outputTokens;
+    }
+
+    private tokenIndexOf(tokenType: TokenType, tokens: Token[]) {
+        for (let i = 0; i < tokens.length; i++) {
+            let token = tokens[i];
+            if (token.tokenType === tokenType) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Get the tokens for the whole line starting at the given index (including the newline or EOF token at the end)
+     * @param startIndex
+     * @param tokens
+     */
+    private getLineTokens(startIndex: number, tokens: Token[]) {
+        let outputTokens: Token[] = [];
+        let index = startIndex;
+        for (index = startIndex; index < tokens.length; index++) {
+            let token = tokens[index];
+            outputTokens[outputTokens.length] = token;
+
+            if (
+                token.tokenType === TokenType.newline ||
+                token.tokenType === TokenType.END_OF_FILE
+            ) {
+                break;
+            }
+        }
+        return {
+            startIndex,
+            stopIndex: index,
+            tokens: outputTokens
+        };
+    }
+
+    private normalizeOptions(options: FormattingOptions | undefined) {
+        let fullOptions: FormattingOptions = {
+            indentStyle: 'spaces',
+            indentSpaceCount: BrightScriptFormatter.DEFAULT_INDENT_SPACE_COUNT,
+            keywordCase: 'lower',
+            compositeKeywords: 'split',
+            removeTrailingWhiteSpace: true
+        };
+        if (options) {
+            for (let attrname in options) {
+                fullOptions[attrname] = options[attrname];
+            }
+        }
+        return fullOptions;
+    }
+
+    private isSingleLineIfStatement(lineTokens: Token[], allTokens: Token[]) {
+        let ifIndex = this.tokenIndexOf(TokenType.if, lineTokens);
+        if (ifIndex === -1) {
+            return false;
+        }
+        let thenIndex = this.tokenIndexOf(TokenType.then, lineTokens);
+        let elseIndex = this.tokenIndexOf(TokenType.else, lineTokens);
+        //if there's an else on this line, assume this is a one-line if statement
+        if (elseIndex > -1) {
+            return true;
+        }
+        //if there's no then, then it can't be a one line statement
+        if (thenIndex === -1) {
+            return false;
+        }
+
+        //see if there is anything after the "then". If so, assume it's a one-line if statement
+        for (let i = thenIndex + 1; i < lineTokens.length; i++) {
+            let token = lineTokens[i];
+            if (
+                token.tokenType === TokenType.whitespace ||
+                token.tokenType === TokenType.newline
+            ) {
+                //do nothing with whitespace and newlines
+            } else {
+                //we encountered a non whitespace and non newline token, so this line must be a single-line if statement
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * A set of formatting options used to determine how the file should be formatted.
+ */
+export interface FormattingOptions {
+    /**
+     * The type of indentation to use when indenting the beginning of lines.
+     */
+    indentStyle?: 'tabs' | 'spaces' | 'existing';
+    /**
+     * The number of spaces to use when indentStyle is 'spaces'. Default is 4
+     */
+    indentSpaceCount?: number;
+    /**
+     * Replaces all keywords with the upper or lower case settings specified.
+     * If set to null, they are not modified at all.
+     */
+    keywordCase?: 'lower' | 'upper' | 'title' | null;
+    /**
+     * Forces all composite keywords (i.e. "elseif", "endwhile", etc...) to be consistent.
+     * If 'split', they are split into their alternatives ("else if", "end while").
+     * If 'combine', they are combined ("elseif", "endwhile").
+     * If null, they are not modified.
+     */
+    compositeKeywords?: 'split' | 'combine' | null;
+    /**
+     * If true (the default), trailing white space is removed
+     * If false, trailing white space is left intact
+     */
+    removeTrailingWhiteSpace?: boolean;
+}

--- a/src/BrightscriptDeclaration.ts
+++ b/src/BrightscriptDeclaration.ts
@@ -1,0 +1,26 @@
+import {Position, Range, SymbolKind} from "vscode";
+
+export class BrightscriptDeclaration {
+    constructor(
+        public name: string,
+        public kind: SymbolKind,
+        public container: BrightscriptDeclaration | undefined,
+        public params: string[],
+        public nameRange: Range,
+        public bodyRange: Range) {
+
+    }
+
+
+    get isGlobal(): boolean {
+        return this.container === undefined;
+    }
+
+    get containerName(): string | undefined {
+        return this.container && this.container.name;
+    }
+
+    public visible(position: Position): boolean {
+        return this.container === undefined || this.container.bodyRange.contains(position);
+    }
+}

--- a/src/BrightscriptDeclaration.ts
+++ b/src/BrightscriptDeclaration.ts
@@ -1,26 +1,44 @@
-import {Position, Range, SymbolKind} from "vscode";
-
+import { Location, Position, Range, SymbolKind, Uri, TextDocument } from "vscode";
+import * as vscode from "vscode";
 export class BrightscriptDeclaration {
-    constructor(
-        public name: string,
-        public kind: SymbolKind,
-        public container: BrightscriptDeclaration | undefined,
-        public params: string[],
-        public nameRange: Range,
-        public bodyRange: Range) {
+  constructor(
+    public name: string,
+    public kind: SymbolKind,
+    public container: BrightscriptDeclaration | undefined,
+    public params: string[],
+    public nameRange: Range,
+    public bodyRange: Range,
+    public uri: Uri | undefined = undefined) {
+  }
+  static fromUri(uri: Uri) {
+    let documentName = uri.path;
+    return new BrightscriptDeclaration(documentName, vscode.SymbolKind.File, undefined, [], new vscode.Range(0,0,0,0), new vscode.Range(0,0,0, 0), uri);
+}
+  get isGlobal(): boolean {
+    return true;
+    // TODO add scope
+    // return this.container === undefined;
+  }
 
+  get containerName(): string | undefined {
+    return this.container && this.container.name;
+  }
+
+  public visible(position: Position): boolean {
+    return true;
+    // return this.container === undefined || this.container.bodyRange.contains(position);
+  }
+  public getDocumentUri(): Uri {
+    if (this.kind === SymbolKind.File) {
+      return this.uri;
+    } else if (this.container) {
+      return this.container.getDocumentUri();
+    } else {
+      console.log("getDocumentUri: ERROR could not find container for symbol" + this);
     }
+  }
+  getLocation(): Location {
+    return new Location(this.getDocumentUri(), this.nameRange);
+  }
 
-
-    get isGlobal(): boolean {
-        return this.container === undefined;
-    }
-
-    get containerName(): string | undefined {
-        return this.container && this.container.name;
-    }
-
-    public visible(position: Position): boolean {
-        return this.container === undefined || this.container.bodyRange.contains(position);
-    }
 }

--- a/src/BrightscriptDefinitionProvider.ts
+++ b/src/BrightscriptDefinitionProvider.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+import {
+  CancellationToken, 
+  Definition,
+  DefinitionProvider, 
+  Position, 
+  TextDocument
+} from 'vscode';
+
+import { DefinitionRepository } from "./DefinitionRepository";
+
+export default class BrightscriptDefinitionProvider implements DefinitionProvider {
+  private repo: DefinitionRepository;
+
+  constructor(repo: DefinitionRepository) {
+    this.repo = repo;
+  }
+
+  public async provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Definition> {
+    await this.repo.sync();
+    return Array.from(this.repo.find(document, position));
+  }
+
+}

--- a/src/BrightscriptSignatureHelpProvider.ts
+++ b/src/BrightscriptSignatureHelpProvider.ts
@@ -1,0 +1,57 @@
+import {
+  TextDocument,
+  SignatureHelpProvider,
+  SignatureHelp,
+  CancellationToken,
+  SignatureInformation,
+  ParameterInformation,
+  ProviderResult, Position, DefinitionProvider, MarkdownString
+} from "vscode";
+import { DefinitionRepository } from "./DefinitionRepository";
+import { BrightscriptDeclaration } from "./BrightscriptDeclaration";
+import BrightscriptDefinitionProvider from "./BrightscriptDefinitionProvider";
+
+export default class BrightscriptSignatureHelpProvider implements SignatureHelpProvider {
+  definitionRepo: DefinitionRepository;
+
+  public constructor(provider: DefinitionRepository) {
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<11");
+    this.definitionRepo = provider;
+  }
+  //1. Get symbold
+  //2. Get param
+  //
+  //
+  public async provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken): Promise<SignatureHelp> {
+    //TODO make sure we're on the definition, not the space, or after it.. 
+    const adjustedPosition = new Position(position.line, position.character - 1);
+    let definition: any;
+    //   return {
+    //     activeParameter: 0,
+    //     activeSignature: 0,
+    //     signatures: [{
+    //         label: "LABEL",
+    //         parameters: [
+    //             {
+    //                 label: "PARAM_LABEL",
+    //                 documentation: "PARAM_DOC",
+    //             }
+    //         ]
+    //     }]
+    // };
+    while (definition = await this.definitionRepo.findDefinition(document, adjustedPosition).next()) {
+      let signatureHelp = new SignatureHelp();
+      let signatureInfo = new SignatureInformation(definition.value.name + "(" +definition.value.params.join(", ")+")");
+
+      let params: ParameterInformation[] = [];
+      definition.value.params.forEach(param => params.push(new ParameterInformation(param, param)));
+      signatureInfo.parameters = params;
+
+      signatureHelp.signatures.push(signatureInfo);
+      signatureHelp.activeParameter = 0;
+      signatureHelp.activeSignature = 0;
+      return signatureHelp;
+    }
+    return undefined;
+  }
+}  

--- a/src/BrightscriptSignatureHelpProvider.ts
+++ b/src/BrightscriptSignatureHelpProvider.ts
@@ -17,7 +17,6 @@ export default class BrightscriptSignatureHelpProvider implements SignatureHelpP
   definitionRepo: DefinitionRepository;
 
   public constructor(provider: DefinitionRepository) {
-    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<11");
     this.definitionRepo = provider;
   }
   //1. Get symbold
@@ -29,7 +28,8 @@ export default class BrightscriptSignatureHelpProvider implements SignatureHelpP
     //get the position of a symbol to our left
     //1. get first bracket to our left, - then get the symbol before that..
     //really crude crappy parser.. 
-    let closeBracketCount = 0;
+    //TODO this is whack - it's not even LTR ugh..
+    let bracketCounts = {normal:0, square:0, curly:0};
     let commaCount = 0;
     let index = position.character;
     let line = document.getText(new Range(position.line, 0, position.line, position.character));
@@ -41,18 +41,30 @@ export default class BrightscriptSignatureHelpProvider implements SignatureHelpP
         }
       } else {
         if (line.charAt(index) === ")") {
-          closeBracketCount++;
+          bracketCounts.normal++;
         }
-        if (line.charAt(index) === "," && closeBracketCount === 0) {
+        if (line.charAt(index) === "]") {
+          bracketCounts.square++;
+        }
+        if (line.charAt(index) === "}") {
+          bracketCounts.curly++;
+        }
+        if (line.charAt(index) === "," && bracketCounts.normal <= 0 && bracketCounts.curly <= 0 && bracketCounts.square <= 0) {
           commaCount++;
         }
 
         if (line.charAt(index) === "(") {
-          if (closeBracketCount === 0) {
+          if (bracketCounts.normal === 0) {
             isArgStartFound = true;
           } else {
-            closeBracketCount--;
+            bracketCounts.normal--;
           }
+        }
+        if (line.charAt(index) === "[") {
+          bracketCounts.square--;
+        }
+        if (line.charAt(index) === "{") {
+          bracketCounts.curly--;
         }
       }
       index--;

--- a/src/DebugErrorHandler.ts
+++ b/src/DebugErrorHandler.ts
@@ -50,7 +50,7 @@ export function registerDebugErrorHandler() {
     if (doc !== undefined) {
       documentUri = doc.uri;
     }
-    console.log("got " + documentUri);
+    // console.log("got " + documentUri);
 
     //debug crap - for some reason - using this URI works - using the one from the path does not :()
     // const document = vscode.window.activeTextEditor.document;

--- a/src/DebugErrorHandler.ts
+++ b/src/DebugErrorHandler.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+import { BrightscriptDebugCompileError } from "./RokuAdapter";
+import URI from "vscode-uri";
+
+const collection = vscode.languages.createDiagnosticCollection('Brightscript');
+
+export function registerDebugErrorHandler() {
+  vscode.debug.onDidStartDebugSession(e => {
+    collection.clear();
+  });
+
+  let _channel: vscode.OutputChannel;
+  function getOutputChannel(): vscode.OutputChannel {
+    if (!_channel) {
+      _channel = vscode.window.createOutputChannel('Brightscript Log');
+    }
+    return _channel;
+  }
+  vscode.debug.onDidReceiveDebugSessionCustomEvent(e => {
+    console.log("received event " + e.event);
+    if (e.event === "BSLogOutputEvent") {
+      getOutputChannel().appendLine(e.body);
+    } else {
+
+
+      collection.clear();
+      let errorsByPath = {};
+      e.body.forEach(async compileError => {
+        if (!errorsByPath[compileError.path]) {
+          errorsByPath[compileError.path] = [];
+        }
+        errorsByPath[compileError.path].push(compileError);
+      });
+
+      for (const path in errorsByPath) {
+        if (errorsByPath.hasOwnProperty(path)) {
+          const errors = errorsByPath[path];
+          addDiagnosticForError(path, errors);
+        }
+      }
+    }
+  });
+
+  async function addDiagnosticForError(path: string, compileErrors: BrightscriptDebugCompileError[]) {
+
+    //TODO get the actual folder
+    let documentUri: vscode.Uri = undefined;
+    let uri = vscode.Uri.file(path);
+    let doc = await vscode.workspace.openTextDocument(uri); // calls back
+    if (doc !== undefined) {
+      documentUri = doc.uri;
+    }
+    console.log("got " + documentUri);
+
+    //debug crap - for some reason - using this URI works - using the one from the path does not :()
+    // const document = vscode.window.activeTextEditor.document;
+    // const currentDocumentUri = document.uri;
+    // console.log("currentDocumentUri " + currentDocumentUri);
+    if (documentUri !== undefined) {
+      {
+        let diagnostics: vscode.Diagnostic[] = [];
+        compileErrors.forEach(compileError => {
+
+          const path: string = compileError.path;
+          const message: string = compileError.message;
+          const source: string = compileError.errorText;
+          const lineNumber: number = compileError.lineNumber;
+          const charStart: number = compileError.charStart;
+          const charEnd: number = compileError.charEnd;
+
+          diagnostics.push({
+            code: '',
+            message: message,
+            range: new vscode.Range(new vscode.Position(lineNumber, charStart), new vscode.Position(lineNumber, charEnd)),
+            severity: vscode.DiagnosticSeverity.Error,
+            source: source
+          });
+        });
+        collection.set(documentUri, diagnostics);
+      }
+    }
+  }
+}

--- a/src/DeclarationProvider.ts
+++ b/src/DeclarationProvider.ts
@@ -64,7 +64,7 @@ export function readDeclarations(uri : Uri, input: string): BrightscriptDeclarat
     //FUNCTION END
     match = /^\s*(end)\s*(function|sub)/i.exec(text);
     if (match !== null) {
-      console.log("function END");
+      // console.log("function END");
       if (currentFunction !== undefined) {
         currentFunction.bodyRange = currentFunction.bodyRange.with({ end: new Position(funcEndLine, funcEndChar) });
       }
@@ -174,7 +174,6 @@ export class DeclarationProvider implements Disposable {
   }
 
   public sync(): Promise<void> {
-    console.log("syncing 11");
     if (this.syncing === undefined) {
       this.syncing = this.flush().then(() => {
         this.syncing = undefined;

--- a/src/DeclarationProvider.ts
+++ b/src/DeclarationProvider.ts
@@ -204,11 +204,16 @@ export class DeclarationProvider implements Disposable {
     this.encoding.reset();
     this.onDidResetEmitter.fire();
   }
-
   private async flush(): Promise<void> {
+    const exclude = [
+      ...Object.keys(await vscode.workspace.getConfiguration('search', null).get('exclude') || {}),
+      ...Object.keys(await vscode.workspace.getConfiguration('files', null).get('exclude') || {})
+    ].join(',');
+  
     if (this.fullscan) {
       this.fullscan = false;
-      for (const uri of await vscode.workspace.findFiles("**/*.brs")) {
+      
+      for (const uri of await vscode.workspace.findFiles("**/*.brs", `{${exclude}}`)) {
         this.dirty.set(uri.fsPath, uri);
       }
     }

--- a/src/DefinitionRepository.ts
+++ b/src/DefinitionRepository.ts
@@ -82,7 +82,6 @@ export class DefinitionRepository {
   }
   
   private findInDocument(document: TextDocument, word: string): Location[] {
-    console.log("FID >>>> "  + document.fileName);
     return readDeclarations(document.uri, document.getText())
       .filter((d) => d.name.toLowerCase() === word && d.isGlobal)
       .map((d) => d.getLocation());

--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -3,759 +3,948 @@ import * as EventEmitter from 'events';
 import * as eol from 'eol';
 import * as rokuDeploy from 'roku-deploy';
 import * as net from 'net';
-
-
 /**
  * A class that connects to a Roku device over telnet debugger port and provides a standardized way of interacting with it.
  */
 export class RokuAdapter {
-    constructor(private host: string) {
-        this.emitter = new EventEmitter();
+  constructor(private host: string) {
+    this.emitter = new EventEmitter();
+    this.status = RokuAdapterStatus.none;
+    this.startCompilingLine = -1;
+    this.endCompilingLine = -1;
+    this.compilingLines = [];
+    this.lastUnhandledDataTime = 0;
+    this.maxDataMsWhenCompiling = 500;
+  }
+
+  private status: RokuAdapterStatus;
+  private requestPipeline: RequestPipeline;
+  private emitter: EventEmitter;
+  private startCompilingLine: number;
+  private endCompilingLine: number;
+  private compilingLines: string[];
+  private lastUnhandledDataTime: number;
+  private maxDataMsWhenCompiling: number;
+  private staleTimer: any;
+
+
+  private cache = {};
+  /**
+   * Subscribe to various events
+   * @param eventName 
+   * @param handler 
+   */
+  public on(eventName: 'suspend', handler: () => void);
+  public on(eventname: 'console-output', handler: (output: string) => void);
+  public on(eventname: 'unhandled-console-output', handler: (output: string) => void);
+  public on(eventName: 'compile-errors', handler: (params: { path: string; lineNumber: number; }[]) => void);
+  public on(eventName: 'close', handler: () => void);
+  public on(eventName: 'runtime-error', handler: (error: BrightScriptRuntimeError) => void);
+  public on(eventName: 'cannot-continue', handler: () => void);
+  public on(eventName: string, handler: (payload: any) => void) {
+    this.emitter.on(eventName, handler);
+    return () => {
+      if (this.emitter !== undefined) {
+        this.emitter.removeListener(eventName, handler);
+      }
+    };
+  }
+
+  private emit(eventName: 'suspend' | 'compile-errors' | 'close' | 'console-output' | 'unhandled-console-output' | 'runtime-error' | 'cannot-continue', data?) {
+    this.emitter.emit(eventName, data);
+  }
+
+  /**
+   * The debugger needs to tell us when to be active (i.e. when the package was deployed)
+   */
+  public isActivated = false;
+  /**
+   * Every time we get a message that ends with the debugger prompt, 
+   * this will be set to true. Otherwise, it will be set to false
+   */
+  public isAtDebuggerPrompt = false;
+  public async activate() {
+    this.isActivated = true;
+    //if we are already sitting at a debugger prompt, we need to emit the first suspend event.
+    //If not, then there are probably still messages being received, so let the normal handler
+    //emit the suspend event when it's ready
+    if (this.isAtDebuggerPrompt === true) {
+      let threads = await this.getThreads();
+      this.emit('suspend', threads[0].threadId);
+
     }
-    private requestPipeline: RequestPipeline;
-    private emitter: EventEmitter;
+  }
 
-    private cache = {};
-
-    /**
-     * Subscribe to various events
-     * @param eventName 
-     * @param handler 
-     */
-    public on(eventName: 'suspend', handler: () => void);
-    public on(eventname: 'console-output', handler: (output: string) => void);
-    public on(eventname: 'unhandled-console-output', handler: (output: string) => void);
-    public on(eventName: 'compile-errors', handler: (params: { path: string; lineNumber: number; }[]) => void);
-    public on(eventName: 'close', handler: () => void);
-    public on(eventName: 'runtime-error', handler: (error: BrightScriptRuntimeError) => void);
-    public on(eventName: 'cannot-continue', handler: () => void);
-    public on(eventName: string, handler: (payload: any) => void) {
-        this.emitter.on(eventName, handler);
-        return () => {
-            this.emitter.removeListener(eventName, handler);
-        };
-    }
-
-    private emit(eventName: 'suspend' | 'compile-errors' | 'close' | 'console-output' | 'unhandled-console-output' | 'runtime-error' | 'cannot-continue', data?) {
-        this.emitter.emit(eventName, data);
-    }
-
-    /**
-     * The debugger needs to tell us when to be active (i.e. when the package was deployed)
-     */
-    public isActivated = false;
-    /**
-     * Every time we get a message that ends with the debugger prompt, 
-     * this will be set to true. Otherwise, it will be set to false
-     */
-    public isAtDebuggerPrompt = false;
-    public async activate() {
-        this.isActivated = true;
-        //if we are already sitting at a debugger prompt, we need to emit the first suspend event.
-        //If not, then there are probably still messages being received, so let the normal handler
-        //emit the suspend event when it's ready
-        if (this.isAtDebuggerPrompt === true) {
-            let threads = await this.getThreads();
-            this.emit('suspend', threads[0].threadId);
-
-        }
-    }
-
-    /**
-     * Wait until the client has stopped sending messages. This is used mainly during .connect so we can ignore all old messages from the server
-     * @param client 
-     * @param name 
-     * @param maxWaitMilliseconds 
-     */
-    private settle(client: Socket, name: string, maxWaitMilliseconds = 400) {
-        return new Promise((resolve, reject) => {
-            let callCount = 0;
-            client.addListener(name, function handler(data) {
-                let myCallCount = callCount;
-                setTimeout(function () {
-                    //if no other calls have been made since the timeout started, then the listener has settled
-                    if (myCallCount === callCount) {
-                        client.removeListener(name, handler);
-                        resolve();
-                    }
-                }, maxWaitMilliseconds);
-            });
-        });
-    }
-
-    /**
-     * Connect to the telnet session. This should be called before the channel is launched, and there should be a breakpoint set at the first
-     * line of the entry function of the source code
-     */
-    public connect() {
-        return new Promise(async (resolve, reject) => {
-            //force roku to return to home screen. This gives the roku adapter some security in knowing new messages won't be appearing during initialization
-            await rokuDeploy.pressHomeButton(this.host);
-
-            let client: Socket = new net.Socket();
-
-            client.connect(8085, this.host, (err, data) => {
-                let k = 2;
-            });
-
-            //listen for the close event
-            client.addListener('close', (err, data) => {
-                this.emit('close');
-            });
-
-            //if the connection fails, reject the connect promise
-            client.addListener('error', function (err) {
-                //this.emit(EventName.error, err);
-                reject(err);
-            });
-
-            await this.settle(client, 'data');
-
-            //hook up the pipeline to the socket
-            this.requestPipeline = new RequestPipeline(client);
-
-            //forward all raw counsole output
-            this.requestPipeline.on('console-output', (output) => {
-                this.emit('console-output', output);
-            });
-
-            //listen for any console output that was not handled by other methods in the adapter
-            this.requestPipeline.on('unhandled-console-output', async (responseText: string) => {
-                //if there was a runtime error, handle it
-                let hasRuntimeError = this.checkForRuntimeError(responseText);
-                if (hasRuntimeError) {
-                    this.isAtDebuggerPrompt = true;
-                    return;
-                }
-
-                if (this.checkForCantContinue(responseText)) {
-                    this.isAtDebuggerPrompt = true;
-                    return;
-                }
-
-                //forward all unhandled console output
-                this.emit('unhandled-console-output', responseText);
-
-                let match;
-
-                this.checkForCompileError(responseText);
-
-
-                if (this.isActivated) {
-                    //console.log(dataString);
-
-                    //we are guaranteed that there will be a breakpoint on the first line of the entry sub, so
-                    //wait until we see the brightscript debugger prompt
-                    if (match = /Brightscript\s+Debugger>\s+$/i.exec(responseText)) {
-                        //if we are activated AND this is the first time seeing the debugger prompt since a continue/step action
-                        if (this.isActivated && this.isAtDebuggerPrompt === false) {
-                            this.isAtDebuggerPrompt = true;
-                            this.emit('suspend');
-                        } else {
-                            this.isAtDebuggerPrompt = true;
-                        }
-                    } else {
-                        this.isAtDebuggerPrompt = false;
-                    }
-                }
-            });
-
-            //the adapter is connected and running smoothly. resolve the promise
+  /**
+   * Wait until the client has stopped sending messages. This is used mainly during .connect so we can ignore all old messages from the server
+   * @param client 
+   * @param name 
+   * @param maxWaitMilliseconds 
+   */
+  private settle(client: Socket, name: string, maxWaitMilliseconds = 400) {
+    return new Promise((resolve, reject) => {
+      let callCount = 0;
+      client.addListener(name, function handler(data) {
+        let myCallCount = callCount;
+        setTimeout(function () {
+          //if no other calls have been made since the timeout started, then the listener has settled
+          if (myCallCount === callCount) {
+            client.removeListener(name, handler);
             resolve();
-        });
-    }
+          }
+        }, maxWaitMilliseconds);
+      });
+    });
+  }
 
-    /**
-     * Look through response text for the "Can't continue" text
-     * @param responseText
-     */
-    private checkForCantContinue(responseText: string) {
-        if (/can't continue/gi.exec(responseText.trim())) {
-            this.emit('cannot-continue');
-        }
-    }
+  /**
+   * Connect to the telnet session. This should be called before the channel is launched, and there should be a breakpoint set at the first
+   * line of the entry function of the source code
+   */
+  public connect() {
+    return new Promise(async (resolve, reject) => {
+      //force roku to return to home screen. This gives the roku adapter some security in knowing new messages won't be appearing during initialization
+      await rokuDeploy.pressHomeButton(this.host);
 
-    /**
-     * Look through the given response text for a runtime error
-     * @param responseText
-     */
-    private checkForRuntimeError(responseText: string) {
-        let match = /[\r\n]+(.*)\(runtime\s+error\s+(.*)\)\s+in/.exec(responseText);
-        if (match) {
-            let message = match[1].trim();
-            let errorCode = match[2].trim().toLowerCase();
-            //if the codes encountered are the STOP or scriptBreak() calls, skip them 
-            if (errorCode === '&hf7' || errorCode === '&hf8') {
-                return false;
-            }
-            this.emit('runtime-error', <BrightScriptRuntimeError>{
-                message,
-                errorCode
-            });
-            return true;
-        } else {
-            return false;
-        }
-    }
+      let client: Socket = new net.Socket();
 
-    /**
-     * Look through the given responseText for a compiler error
-     * @param responseText
-     */
-    private checkForCompileError(responseText: string) {
-        //throw out any lines before the last found compiling line
-        let lines = eol.split(responseText);
-        let lastIndex: number = -1;
-        for (let i = 0; i < lines.length; i++) {
-            let line = lines[i];
-            //if this line looks like the compiling line
-            if (/------\s+compiling.*------/i.exec(line)) {
-                lastIndex = i;
-            }
-        }
-        if (lastIndex > -1) {
-            lines = lines.splice(lastIndex);
-            responseText = lines.join('\r\n');
+      client.connect(8085, this.host, (err, data) => {
+        let k = 2;
+      });
+
+      //listen for the close event
+      client.addListener('close', (err, data) => {
+        this.emit('close');
+      });
+
+      //if the connection fails, reject the connect promise
+      client.addListener('error', function (err) {
+        //this.emit(EventName.error, err);
+        reject(err);
+      });
+
+      await this.settle(client, 'data');
+
+      //hook up the pipeline to the socket
+      this.requestPipeline = new RequestPipeline(client);
+
+      //forward all raw counsole output
+      this.requestPipeline.on('console-output', (output) => {
+        this.emit('console-output', output);
+      });
+
+      //listen for any console output that was not handled by other methods in the adapter
+      this.requestPipeline.on('unhandled-console-output', async (responseText: string) => {
+        //if there was a runtime error, handle it
+        let hasRuntimeError = this.checkForRuntimeError(responseText);
+        if (hasRuntimeError) {
+          this.isAtDebuggerPrompt = true;
+          return;
         }
 
-        //if there is a line with a compiler error in it, emit an event
+        //forward all unhandled console output
+        this.emit('unhandled-console-output', responseText);
+
+        this.processUnhandledLines(responseText);
         let match;
-        let regexp = /compile error.* in (.*)\((\d+)\)/gi;
-        let errors: { path: string; lineNumber: number }[] = [];
 
-        while (match = regexp.exec(responseText)) {
-            let path = match[1];
-            let lineNumber = parseInt(match[2]);
-            //if this match is a livecompile error, throw out all prior errors because that means we are re-running
-            if (path.toLowerCase().indexOf('$livecompile') > -1) {
-                errors = [];
+        if (this.checkForCantContinue(responseText)) {
+          this.isAtDebuggerPrompt = true;
+          return;
+        }
+
+        if (this.isActivated) {
+          //console.log(dataString);
+
+          //we are guaranteed that there will be a breakpoint on the first line of the entry sub, so
+          //wait until we see the brightscript debugger prompt
+          if (match = /Brightscript\s+Debugger>\s+$/i.exec(responseText)) {
+            //if we are activated AND this is the first time seeing the debugger prompt since a continue/step action
+            if (this.isActivated && this.isAtDebuggerPrompt === false) {
+              this.isAtDebuggerPrompt = true;
+              this.emit('suspend');
             } else {
-                errors.push({
-                    path,
-                    lineNumber
-                });
+              this.isAtDebuggerPrompt = true;
             }
+          } else {
+            this.isAtDebuggerPrompt = false;
+          }
         }
-        if (errors.length > 0) {
-            this.emit('compile-errors', errors);
-        }
+      });
+
+      //the adapter is connected and running smoothly. resolve the promise
+      resolve();
+    });
+  }
+
+  /**
+   * Look through response text for the "Can't continue" text
+   * @param responseText
+   */
+  private checkForCantContinue(responseText: string): boolean {
+    if (/can't continue/gi.exec(responseText.trim())) {
+      this.emit('cannot-continue');
+      return true;
     }
-    /**
-     * Send command to step over
-     */
-    public stepOver() {
-        this.clearCache();
-        return this.requestPipeline.executeCommand('over', false);
+    return false;
+  }
+
+  /**
+   * Look through the given response text for a runtime error
+   * @param responseText
+   */
+  private checkForRuntimeError(responseText: string) {
+    let match = /[\r\n]+(.*)\(runtime\s+error\s+(.*)\)\s+in/.exec(responseText);
+    if (match) {
+      let message = match[1].trim();
+      let errorCode = match[2].trim().toLowerCase();
+      //if the codes encountered are the STOP or scriptBreak() calls, skip them 
+      if (errorCode === '&hf7' || errorCode === '&hf8') {
+        return false;
+      }
+      this.emit('runtime-error', <BrightScriptRuntimeError>{
+        message,
+        errorCode
+      });
+      return true;
+    } else {
+      return false;
     }
+  }
 
-    public stepInto() {
-        this.clearCache();
-        return this.requestPipeline.executeCommand('step', false);
-    }
-
-    public stepOut() {
-        this.clearCache();
-        return this.requestPipeline.executeCommand('out', false);
-
-    }
-
-    /**
-     * Tell the brightscript program to continue (i.e. resume program)
-     */
-    public continue() {
-        this.clearCache();
-        return this.requestPipeline.executeCommand('c', false);
-    }
-
-    /**
-     * Tell the brightscript program to pause (fall into debug mode)
-     */
-    public pause() {
-        this.clearCache();
-        //send the kill signal, which breaks into debugger mode
-        return this.requestPipeline.executeCommand('\x03;', false);
-    }
-
-    /**
-     * Clears the state, which means that everything will be retrieved fresh next time it is requested
-     */
-    public clearCache() {
-        this.cache = {};
-        this.isAtDebuggerPrompt = false;
-    }
-
-    /**
-     * Execute a command directly on the roku. Returns the output of the command
-     * @param command 
-     */
-    public async evaluate(command: string) {
-        if (!this.isAtDebuggerPrompt) {
-            throw new Error('Cannot run evaluate: debugger is not paused');
-        }
-        //clear the cache (we don't know what command the user entered)
-        this.clearCache();
-        //don't wait for the output...we don't know what command the user entered
-        let responseText = await this.requestPipeline.executeCommand(command, true);
-        //we know that if we got a response, we are back at a debugger prompt
-        this.isAtDebuggerPrompt = true;
-        return responseText;
-    }
-
-    public async getStackTrace() {
-        if (!this.isAtDebuggerPrompt) {
-            throw new Error('Cannot get stack trace: debugger is not paused');
-        }
-        return await this.resolve('stackTrace', async () => {
-            //perform a request to load the stack trace
-            let responseText = await this.requestPipeline.executeCommand('bt', true);
-            let regexp = /#(\d+)\s+(?:function|sub)\s+([\$\w\d]+).*\s+file\/line:\s+(.*)\((\d+)\)/ig;
-            let matches;
-            let frames: StackFrame[] = [];
-            while (matches = regexp.exec(responseText)) {
-                //the first index is the whole string
-                //then the matches should be in pairs
-                for (let i = 1; i < matches.length; i = i + 4) {
-                    let j = 1;
-                    let frameId = parseInt(matches[i]);
-                    let functionIdentifier = matches[i + j++];
-                    let filePath = matches[i + j++];
-                    let lineNumber = parseInt(matches[i + j++]);
-                    let frame: StackFrame = {
-                        frameId,
-                        filePath,
-                        lineNumber,
-                        functionIdentifier
-                    };
-                    frames.push(frame);
-                }
-            }
-            //if we didn't find frames yet, then there's not much more we can do...
-            return frames;
-        });
-    }
-
-
-    private expressionRegex = /([\s|\S]+?)(?:\r|\r\n)+brightscript debugger>/i;
-    /**
-     * Given an expression, evaluate that statement ON the roku
-     * @param expression
-     */
-    public async getVariable(expression: string) {
-        if (!this.isAtDebuggerPrompt) {
-            throw new Error('Cannot resolve variable: debugger is not paused');
-        }
-        return await this.resolve(`variable: ${expression}`, async () => {
-            let expressionType = await this.getVariableType(expression);
-
-            let lowerExpressionType = expressionType ? expressionType.toLowerCase() : null;
-
-            let data: string;
-            //if the expression type is a string, we need to wrap the expression in quotes BEFORE we run the print so we can accurately capture the full string value
-            if (lowerExpressionType === 'string' || lowerExpressionType === 'rostring') {
-                data = await this.requestPipeline.executeCommand(`print "--string-wrap--" + ${expression} + "--string-wrap--"`, true);
-            }
-            else {
-                data = await this.requestPipeline.executeCommand(`print ${expression}`, true);
-            }
-
-            let match;
-            if (match = this.expressionRegex.exec(data)) {
-                let value = match[1];
-                if (lowerExpressionType === 'string' || lowerExpressionType === 'rostring') {
-                    value = value.trim().replace(/--string-wrap--/g, '');
-                    //add an escape character in front of any existing quotes
-                    value = value.replace(/"/g, '\\"');
-                    //wrap the string value with literal quote marks
-                    value = '"' + value + '"';
-                } else {
-                    value = value.trim();
-                }
-
-                let highLevelType = this.getHighLevelType(expressionType);
-
-                let children: EvaluateContainer[];
-                if (highLevelType === 'object') {
-                    children = this.getObjectChildren(expression, value);
-                } else if (highLevelType === 'array') {
-                    children = this.getArrayChildren(expression, value);
-                }
-
-                let container = <EvaluateContainer>{
-                    name: expression,
-                    evaluateName: expression,
-                    type: expressionType,
-                    value: value,
-                    highLevelType,
-                    children
-                };
-                return container;
-            }
-        });
-    }
-
-    private getArrayChildren(expression: string, data: string): EvaluateContainer[] {
-        let children: EvaluateContainer[] = [];
-        //split by newline. the array contents start at index 2
-        let lines = eol.split(data);
-        let arrayIndex = 0;
-        for (let i = 2; i < lines.length; i++) {
-            let line = lines[i].trim();
-            if (line === ']') {
-                return children;
-            }
-            let child = <EvaluateContainer>{
-                name: arrayIndex.toString(),
-                evaluateName: `${expression}[${arrayIndex}]`,
-                children: []
-            };
-
-            //if the line is an object, array or function
-            let match;
-            if (match = /<.*:\s+(\w*)>/gi.exec(line)) {
-                let type = match[1];
-                child.type = type;
-                child.highLevelType = this.getHighLevelType(type);
-                child.value = type;
-            } else {
-                child.type = this.getPrimativeTypeFromValue(line);
-                child.value = line;
-                child.highLevelType = HighLevelType.primative;
-            }
-            children.push(child);
-            arrayIndex++;
-        }
-        throw new Error('Unable to parse BrightScript array');
-    }
-
-    private getPrimativeTypeFromValue(value: string): PrimativeType {
-        value = value ? value.toLowerCase() : value;
-        if (!value || value === 'invalid') {
-            return PrimativeType.invalid;
-        }
-        if (value === 'true' || value === 'false') {
-            return PrimativeType.boolean;
-        }
-        if (value.indexOf('"') > -1) {
-            return PrimativeType.string;
-        }
-        if (value.split('.').length > 1) {
-            return PrimativeType.integer;
+  private processUnhandledLines(responseText: string) {
+    let newLines = eol.split(responseText);
+    switch (this.status) {
+      case RokuAdapterStatus.compiling:
+        this.endCompilingLine = this.getEndCompilingLine(newLines);
+        if (this.endCompilingLine !== -1) {
+          console.log("processUnhandledLines: entering state RokuAdapterStatus.running");
+          this.status = RokuAdapterStatus.running;
+          this.resetCompilingStaleTimer(false);
         } else {
-            return PrimativeType.float;
+          this.compilingLines = this.compilingLines.concat(newLines);
+          this.resetCompilingStaleTimer(true);
         }
+        break;
+      case RokuAdapterStatus.compileError:
+        console.debug("ignoring lines while status = RokuAdapterStatus.compileError " + responseText);
+        break;
+      case RokuAdapterStatus.running:
+        console.debug("ignoring unhandle lines while stauts = RokuAdapterStatus.running " + responseText);
+        break;
+      case RokuAdapterStatus.none:
+        this.startCompilingLine = this.getStartingCompilingLine(newLines);
+        if (this.startCompilingLine !== -1) {
+          console.log("processUnhandledLines: entering state RokuAdapterStatus.compiling");
+          newLines.splice(0, this.startCompilingLine);
+          this.status = RokuAdapterStatus.compiling;
+          this.resetCompilingStaleTimer(true);
+        }
+        break;
+    }
+  }
+  resetCompilingStaleTimer(isRunning): any {
+    console.log("getStartingCompilingLine isRunning" + isRunning);
 
+    if (this.staleTimer) {
+      console.log(">>>clearing existing interval");
+      clearInterval(this.staleTimer);
+      this.staleTimer = undefined;
     }
 
-    private getObjectChildren(expression: string, data: string): EvaluateContainer[] {
-        try {
-            let children: EvaluateContainer[] = [];
-            //split by newline. the object contents start at index 2
-            let lines = eol.split(data);
-            for (let i = 2; i < lines.length; i++) {
-                let line = lines[i].trim();
-                if (line === '}') {
-                    return children;
-                }
-                let match;
-                match = /(\w+):(.+)/i.exec(line);
-                let name = match[1].trim();
-                let value = match[2].trim();
-
-                let child = <EvaluateContainer>{
-                    name: name,
-                    evaluateName: `${expression}.${name}`,
-                    children: []
-                };
-
-                //if the line is an object, array or function
-                if (match = /<.*:\s+(\w*)>/gi.exec(line)) {
-                    let type = match[1];
-                    child.type = type;
-                    child.highLevelType = this.getHighLevelType(type);
-                    child.value = type;
-                } else {
-                    child.type = this.getPrimativeTypeFromValue(line);
-                    child.value = value;
-                    child.highLevelType = HighLevelType.primative;
-                }
-                children.push(child);
-            }
-            return children;
-        } catch (e) {
-            throw new Error(`Unable to parse BrightScript object: ${e.message}. Data: ${data}`);
-        }
+    if (isRunning) {
+      let that = this;
+      this.staleTimer = setInterval(() => this.onCompilingStaleTimer(), 2000);
     }
+  }
 
-    /**
-     * Determine if this value is a primative type
-     * @param expressionType 
-     */
-    private getHighLevelType(expressionType: string) {
-        if (!expressionType) {
-            throw new Error(`Unknown expression type: ${expressionType}`);
+  onCompilingStaleTimer() {
+    if (this.status !== RokuAdapterStatus.compileError) {
+      console.log("+++++++++onCompilingStaleTimer: took too long while in compile mode - assuming it's an error");
+      this.status = RokuAdapterStatus.compileError;
+      this.resetCompilingStaleTimer(false);
+      this.reportErrors();
+    } else {
+      console.log("+++++++++onCompilingStaleTimer: CALLED WHEN ALREADY IN ERROR STATE");
+
+    }
+  }
+
+  private getStartingCompilingLine(lines: string[]): number {
+    let lastIndex: number = -1;
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      //if this line looks like the compiling line
+      if (/------\s+compiling.*------/i.exec(line)) {
+        lastIndex = i;
+      }
+    }
+    return lastIndex;
+  }
+
+  private getEndCompilingLine(lines: string[]): number {
+    let lastIndex: number = -1;
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      //if this line looks like the compiling line
+      if (/------\s+Running.*------/i.exec(line)) {
+        lastIndex = i;
+      }
+    }
+    return lastIndex;
+
+  }
+  /**
+   * Look through the given responseText for a compiler error
+   * @param responseText
+   */
+  private reportErrors() {
+    console.log(">>>>>>>>>>>>>>>>>> reportErrors");
+    //throw out any lines before the last found compiling line
+    
+    let syntaxErrors = this.getSyntaxErrors(this.compilingLines);
+    let compileErrors = this.getCompileErrors(this.compilingLines);
+    let errors = syntaxErrors.concat(compileErrors);
+    
+    errors = errors.filter(e => e.path.toLowerCase().endsWith(".brs") || e.path.toLowerCase().endsWith(".xml"));
+    
+    console.log(">>>>>>>>>>>>>>>>>> errors.length " + errors.length);
+    if (errors.length > 0) {
+      this.emit('compile-errors', errors);
+    }
+  }
+
+  getSyntaxErrors(lines: string[]): BrightscriptDebugCompileError[] {
+    let match;
+    let errors = [];
+    let syntaxRegEx = /(syntax|compile) error.* in (.*)\((\d+)\)/gim;
+    lines.forEach(line => {
+      match = syntaxRegEx.exec(line);
+      if (match) {
+        let path = match[2];
+        let lineNumber = parseInt(match[3]) - 1;
+
+        //FIXME
+        //if this match is a livecompile error, throw out all prior errors because that means we are re-running
+        if (path.toLowerCase().indexOf('$livecompile') === -1) {
+
+          errors.push({
+            path,
+            lineNumber,
+            line,
+            message: match[0],
+            charStart: 0,
+            charEnd: 999 //TODO
+          });
         }
+      }
+    });
+    return errors;
+  }
 
-        expressionType = expressionType.toLowerCase();
-        let primativeTypes = ['boolean', 'integer', 'longinteger', 'float', 'double', 'string', 'rostring', 'invalid'];
-        if (primativeTypes.indexOf(expressionType) > -1) {
-            return HighLevelType.primative;
-        } else if (expressionType === 'roarray') {
-            return HighLevelType.array;
-        } else if (expressionType === 'function') {
-            return HighLevelType.function;
-        } else if (expressionType === '<uninitialized>') {
-            return HighLevelType.uninitialized;
+  getCompileErrors(lines: string[]): BrightscriptDebugCompileError[] {
+    let errors = [];
+    let match;
+    let responseText = lines.join("\n");
+    const filesWithErrors = responseText.split("=================================================================");
+    if (filesWithErrors.length < 2) {
+      return [];
+    }
+    for (let index = 1; index < filesWithErrors.length - 1; index++) {
+      const fileErrorText = filesWithErrors[index];
+      //TODO - for now just a simple parse - later on someone can improve with proper line checks + all parse/compile types
+      //don't have time to do this now; just doing what keeps me productive.
+      let getFileInfoRexEx = /found(?:.*)file (.*)$/gim;
+      match = getFileInfoRexEx.exec(fileErrorText);
+      if (!match) {
+        continue;
+      }
+
+      let path = match[1];
+      let lineNumber = 0; //TODO this should iterate over all line numbers found in a file
+      let errorText = "ERR_COMPILE:";
+      let message = fileErrorText;
+
+      errors.push({
+        path,
+        lineNumber,
+        errorText,
+        message,
+        charStart: 0,
+        charEnd: 999 //TODO
+      });
+
+      //now iterate over the lines, to see if there's any errors we can extract
+      let lineErrors = this.getLineErrors(path, fileErrorText);
+      if (lineErrors.length > 0){
+        errors = lineErrors;
+      }
+    }
+    return errors;
+  }
+
+  getLineErrors(path: string, fileErrorText: string): any[] {
+    let errors = [];
+    let getFileInfoRexEx = /^--- Line (\d*): (.*)$/gim;
+    let match;
+    while(match = getFileInfoRexEx.exec(fileErrorText)){
+      let lineNumber = parseInt(match[1]) -1;
+      let errorText = "ERR_COMPILE:";
+      let message = match[2];
+
+      errors.push({
+        path,
+        lineNumber,
+        errorText,
+        message,
+        charStart: 0,
+        charEnd: 999 //TODO
+      });
+    }
+    
+    return errors;
+  }
+
+
+  /**
+   * Send command to step over
+   */
+  public stepOver() {
+    this.clearCache();
+    return this.requestPipeline.executeCommand('over', false);
+  }
+
+  public stepInto() {
+    this.clearCache();
+    return this.requestPipeline.executeCommand('step', false);
+  }
+
+  public stepOut() {
+    this.clearCache();
+    return this.requestPipeline.executeCommand('out', false);
+
+  }
+
+  /**
+   * Tell the brightscript program to continue (i.e. resume program)
+   */
+  public continue() {
+    this.clearCache();
+    return this.requestPipeline.executeCommand('c', false);
+  }
+
+  /**
+   * Tell the brightscript program to pause (fall into debug mode)
+   */
+  public pause() {
+    this.clearCache();
+    //send the kill signal, which breaks into debugger mode
+    return this.requestPipeline.executeCommand('\x03;', false);
+  }
+
+  /**
+   * Clears the state, which means that everything will be retrieved fresh next time it is requested
+   */
+  public clearCache() {
+    this.cache = {};
+    this.isAtDebuggerPrompt = false;
+  }
+
+  /**
+   * Execute a command directly on the roku. Returns the output of the command
+   * @param command 
+   */
+  public async evaluate(command: string) {
+    if (!this.isAtDebuggerPrompt) {
+      throw new Error('Cannot run evaluate: debugger is not paused');
+    }
+    //clear the cache (we don't know what command the user entered)
+    this.clearCache();
+    //don't wait for the output...we don't know what command the user entered
+    let responseText = await this.requestPipeline.executeCommand(command, true);
+    //we know that if we got a response, we are back at a debugger prompt
+    this.isAtDebuggerPrompt = true;
+    return responseText;
+  }
+
+  public async getStackTrace() {
+    if (!this.isAtDebuggerPrompt) {
+      throw new Error('Cannot get stack trace: debugger is not paused');
+    }
+    return await this.resolve('stackTrace', async () => {
+      //perform a request to load the stack trace
+      let responseText = await this.requestPipeline.executeCommand('bt', true);
+      let regexp = /#(\d+)\s+(?:function|sub)\s+([\$\w\d]+).*\s+file\/line:\s+(.*)\((\d+)\)/ig;
+      let matches;
+      let frames: StackFrame[] = [];
+      while (matches = regexp.exec(responseText)) {
+        //the first index is the whole string
+        //then the matches should be in pairs
+        for (let i = 1; i < matches.length; i = i + 4) {
+          let j = 1;
+          let frameId = parseInt(matches[i]);
+          let functionIdentifier = matches[i + j++];
+          let filePath = matches[i + j++];
+          let lineNumber = parseInt(matches[i + j++]);
+          let frame: StackFrame = {
+            frameId,
+            filePath,
+            lineNumber,
+            functionIdentifier
+          };
+          frames.push(frame);
+        }
+      }
+      //if we didn't find frames yet, then there's not much more we can do...
+      return frames;
+    });
+  }
+
+
+  private expressionRegex = /([\s|\S]+?)(?:\r|\r\n)+brightscript debugger>/i;
+  /**
+   * Given an expression, evaluate that statement ON the roku
+   * @param expression
+   */
+  public async getVariable(expression: string) {
+    if (!this.isAtDebuggerPrompt) {
+      throw new Error('Cannot resolve variable: debugger is not paused');
+    }
+    return await this.resolve(`variable: ${expression}`, async () => {
+      let expressionType = await this.getVariableType(expression);
+
+      let lowerExpressionType = expressionType ? expressionType.toLowerCase() : null;
+
+      let data: string;
+      //if the expression type is a string, we need to wrap the expression in quotes BEFORE we run the print so we can accurately capture the full string value
+      if (lowerExpressionType === 'string' || lowerExpressionType === 'rostring') {
+        data = await this.requestPipeline.executeCommand(`print "--string-wrap--" + ${expression} + "--string-wrap--"`, true);
+      }
+      else {
+        data = await this.requestPipeline.executeCommand(`print ${expression}`, true);
+      }
+
+      let match;
+      if (match = this.expressionRegex.exec(data)) {
+        let value = match[1];
+        if (lowerExpressionType === 'string' || lowerExpressionType === 'rostring') {
+          value = value.trim().replace(/--string-wrap--/g, '');
+          //add an escape character in front of any existing quotes
+          value = value.replace(/"/g, '\\"');
+          //wrap the string value with literal quote marks
+          value = '"' + value + '"';
         } else {
-            return HighLevelType.object;
+          value = value.trim();
         }
+
+        let highLevelType = this.getHighLevelType(expressionType);
+
+        let children: EvaluateContainer[];
+        if (highLevelType === 'object') {
+          children = this.getObjectChildren(expression, value);
+        } else if (highLevelType === 'array') {
+          children = this.getArrayChildren(expression, value);
+        }
+
+        let container = <EvaluateContainer>{
+          name: expression,
+          evaluateName: expression,
+          type: expressionType,
+          value: value,
+          highLevelType,
+          children
+        };
+        return container;
+      }
+    });
+  }
+
+  private getArrayChildren(expression: string, data: string): EvaluateContainer[] {
+    let children: EvaluateContainer[] = [];
+    //split by newline. the array contents start at index 2
+    let lines = eol.split(data);
+    let arrayIndex = 0;
+    for (let i = 2; i < lines.length; i++) {
+      let line = lines[i].trim();
+      if (line === ']') {
+        return children;
+      }
+      let child = <EvaluateContainer>{
+        name: arrayIndex.toString(),
+        evaluateName: `${expression}[${arrayIndex}]`,
+        children: []
+      };
+
+      //if the line is an object, array or function
+      let match;
+      if (match = /<.*:\s+(\w*)>/gi.exec(line)) {
+        let type = match[1];
+        child.type = type;
+        child.highLevelType = this.getHighLevelType(type);
+        child.value = type;
+      } else {
+        child.type = this.getPrimativeTypeFromValue(line);
+        child.value = line;
+        child.highLevelType = HighLevelType.primative;
+      }
+      children.push(child);
+      arrayIndex++;
+    }
+    throw new Error('Unable to parse BrightScript array');
+  }
+
+  private getPrimativeTypeFromValue(value: string): PrimativeType {
+    value = value ? value.toLowerCase() : value;
+    if (!value || value === 'invalid') {
+      return PrimativeType.invalid;
+    }
+    if (value === 'true' || value === 'false') {
+      return PrimativeType.boolean;
+    }
+    if (value.indexOf('"') > -1) {
+      return PrimativeType.string;
+    }
+    if (value.split('.').length > 1) {
+      return PrimativeType.integer;
+    } else {
+      return PrimativeType.float;
     }
 
-    /**
-     * Get the type of the provided expression
-     * @param expression 
-     */
-    public async getVariableType(expression) {
-        if (!this.isAtDebuggerPrompt) {
-            throw new Error('Cannot get variable type: debugger is not paused');
-        }
-        expression = `Type(${expression})`;
-        return await this.resolve(`${expression}`, async () => {
-            let data = await this.requestPipeline.executeCommand(`print ${expression}`, true);
+  }
 
-            let match;
-            if (match = this.expressionRegex.exec(data)) {
-                let typeValue: string = match[1];
-                //remove whitespace
-                typeValue = typeValue.trim();
-                return typeValue;
-            } else {
-                return null;
-            }
+  private getObjectChildren(expression: string, data: string): EvaluateContainer[] {
+    try {
+      let children: EvaluateContainer[] = [];
+      //split by newline. the object contents start at index 2
+      let lines = eol.split(data);
+      for (let i = 2; i < lines.length; i++) {
+        let line = lines[i].trim();
+        if (line === '}') {
+          return children;
+        }
+        let match;
+        match = /(\w+):(.+)/i.exec(line);
+        let name = match[1].trim();
+        let value = match[2].trim();
+
+        let child = <EvaluateContainer>{
+          name: name,
+          evaluateName: `${expression}.${name}`,
+          children: []
+        };
+
+        //if the line is an object, array or function
+        if (match = /<.*:\s+(\w*)>/gi.exec(line)) {
+          let type = match[1];
+          child.type = type;
+          child.highLevelType = this.getHighLevelType(type);
+          child.value = type;
+        } else {
+          child.type = this.getPrimativeTypeFromValue(line);
+          child.value = value;
+          child.highLevelType = HighLevelType.primative;
+        }
+        children.push(child);
+      }
+      return children;
+    } catch (e) {
+      throw new Error(`Unable to parse BrightScript object: ${e.message}. Data: ${data}`);
+    }
+  }
+
+  /**
+   * Determine if this value is a primative type
+   * @param expressionType 
+   */
+  private getHighLevelType(expressionType: string) {
+    if (!expressionType) {
+      throw new Error(`Unknown expression type: ${expressionType}`);
+    }
+
+    expressionType = expressionType.toLowerCase();
+    let primativeTypes = ['boolean', 'integer', 'longinteger', 'float', 'double', 'string', 'rostring', 'invalid'];
+    if (primativeTypes.indexOf(expressionType) > -1) {
+      return HighLevelType.primative;
+    } else if (expressionType === 'roarray') {
+      return HighLevelType.array;
+    } else if (expressionType === 'function') {
+      return HighLevelType.function;
+    } else if (expressionType === '<uninitialized>') {
+      return HighLevelType.uninitialized;
+    } else {
+      return HighLevelType.object;
+    }
+  }
+
+  /**
+   * Get the type of the provided expression
+   * @param expression 
+   */
+  public async getVariableType(expression) {
+    if (!this.isAtDebuggerPrompt) {
+      throw new Error('Cannot get variable type: debugger is not paused');
+    }
+    expression = `Type(${expression})`;
+    return await this.resolve(`${expression}`, async () => {
+      let data = await this.requestPipeline.executeCommand(`print ${expression}`, true);
+
+      let match;
+      if (match = this.expressionRegex.exec(data)) {
+        let typeValue: string = match[1];
+        //remove whitespace
+        typeValue = typeValue.trim();
+        return typeValue;
+      } else {
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Cache items by a unique key
+   * @param expression 
+   * @param factory 
+   */
+  private resolve<T>(key: string, factory: () => T | Thenable<T>): Promise<T> {
+    if (this.cache[key]) {
+      return this.cache[key];
+    }
+    return this.cache[key] = Promise.resolve<T>(factory());
+  }
+
+  /**
+   * Get a list of threads. The first thread in the list is the active thread
+   */
+  public async getThreads() {
+    if (!this.isAtDebuggerPrompt) {
+      throw new Error('Cannot get threads: debugger is not paused');
+    }
+    return await this.resolve('threads', async () => {
+      let data = await this.requestPipeline.executeCommand('threads', true);
+
+      let dataString = data.toString();
+      let matches;
+      let threads: Thread[] = [];
+      if (matches = /^\s+(\d+\*)\s+(.*)\((\d+)\)\s+(.*)/gm.exec(dataString)) {
+        //skip index 0 because it's the whole string
+        for (let i = 1; i < matches.length; i = i + 4) {
+          let threadId: string = matches[i];
+          let thread = <Thread>{
+            isSelected: false,
+            filePath: matches[i + 1],
+            lineNumber: parseInt(matches[i + 2]),
+            lineContents: matches[i + 3]
+          };
+          if (threadId.indexOf('*') > -1) {
+            thread.isSelected = true;
+            threadId = threadId.replace('*', '');
+          }
+          thread.threadId = parseInt(threadId);
+          threads.push(thread);
+        }
+        //make sure the selected thread is at the top
+        threads.sort((a, b) => {
+          return a.isSelected ? -1 : 1;
         });
+      }
+      return threads;
+    });
+  }
+
+  /**
+   * Disconnect from the telnet session and unset all objects
+   */
+  public destroy() {
+    if (this.requestPipeline) {
+      this.requestPipeline.destroy();
     }
 
-    /**
-     * Cache items by a unique key
-     * @param expression 
-     * @param factory 
-     */
-    private resolve<T>(key: string, factory: () => T | Thenable<T>): Promise<T> {
-        if (this.cache[key]) {
-            return this.cache[key];
-        }
-        return this.cache[key] = Promise.resolve<T>(factory());
+    this.requestPipeline = undefined;
+    this.cache = undefined;
+    if (this.emitter){
+      this.emitter.removeAllListeners();
     }
-
-    /**
-     * Get a list of threads. The first thread in the list is the active thread
-     */
-    public async getThreads() {
-        if (!this.isAtDebuggerPrompt) {
-            throw new Error('Cannot get threads: debugger is not paused');
-        }
-        return await this.resolve('threads', async () => {
-            let data = await this.requestPipeline.executeCommand('threads', true);
-
-            let dataString = data.toString();
-            let matches;
-            let threads: Thread[] = [];
-            if (matches = /^\s+(\d+\*)\s+(.*)\((\d+)\)\s+(.*)/gm.exec(dataString)) {
-                //skip index 0 because it's the whole string
-                for (let i = 1; i < matches.length; i = i + 4) {
-                    let threadId: string = matches[i];
-                    let thread = <Thread>{
-                        isSelected: false,
-                        filePath: matches[i + 1],
-                        lineNumber: parseInt(matches[i + 2]),
-                        lineContents: matches[i + 3]
-                    };
-                    if (threadId.indexOf('*') > -1) {
-                        thread.isSelected = true;
-                        threadId = threadId.replace('*', '');
-                    }
-                    thread.threadId = parseInt(threadId);
-                    threads.push(thread);
-                }
-                //make sure the selected thread is at the top
-                threads.sort((a, b) => {
-                    return a.isSelected ? -1 : 1;
-                });
-            }
-            return threads;
-        });
-    }
-
-    /**
-     * Disconnect from the telnet session and unset all objects
-     */
-    public destroy() {
-        this.requestPipeline.destroy();
-        this.requestPipeline = undefined;
-        this.cache = undefined;
-        this.emitter.removeAllListeners();
-        this.emitter = undefined;
-    }
+    this.emitter = undefined;
+  }
 }
 
+
 export interface StackFrame {
-    frameId: number;
-    filePath: string;
-    lineNumber: number;
-    functionIdentifier: string;
+  frameId: number;
+  filePath: string;
+  lineNumber: number;
+  functionIdentifier: string;
 }
 
 export enum EventName {
-    suspend = 'suspend'
+  suspend = 'suspend'
 }
 
 export enum HighLevelType {
-    primative = 'primative',
-    array = 'array',
-    function = 'function',
-    object = 'object',
-    uninitialized = 'uninitialized'
+  primative = 'primative',
+  array = 'array',
+  function = 'function',
+  object = 'object',
+  uninitialized = 'uninitialized'
 }
 
 export interface EvaluateContainer {
-    name: string;
-    evaluateName: string;
-    type: string;
-    value: string;
-    highLevelType: HighLevelType;
-    children: EvaluateContainer[];
+  name: string;
+  evaluateName: string;
+  type: string;
+  value: string;
+  highLevelType: HighLevelType;
+  children: EvaluateContainer[];
 }
 
 export interface Thread {
-    isSelected: boolean;
-    lineNumber: number;
-    filePath: string;
-    lineContents: string;
-    threadId: number;
+  isSelected: boolean;
+  lineNumber: number;
+  filePath: string;
+  lineContents: string;
+  threadId: number;
 }
 
 export enum PrimativeType {
-    invalid = 'Invalid',
-    boolean = 'Boolean',
-    string = 'String',
-    integer = 'Integer',
-    float = 'Float'
+  invalid = 'Invalid',
+  boolean = 'Boolean',
+  string = 'String',
+  integer = 'Integer',
+  float = 'Float'
 }
 
 export class RequestPipeline {
-    constructor(
-        private client: Socket
-    ) {
-        this.connect();
-    }
-    private requests: RequestPipelineRequest[] = [];
-    private get isProcessing() {
-        return this.currentRequest !== undefined;
-    }
-    private currentRequest: RequestPipelineRequest = undefined;
+  constructor(
+    private client: Socket
+  ) {
+    this.connect();
+  }
+  private requests: RequestPipelineRequest[] = [];
+  private get isProcessing() {
+    return this.currentRequest !== undefined;
+  }
+  private currentRequest: RequestPipelineRequest = undefined;
 
-    private emitter = new EventEmitter();
+  private emitter = new EventEmitter();
 
-    on(eventName: 'unhandled-console-output' | 'console-output', handler: (data: string) => void);
-    public on(eventName: string, handler: (data: string) => void) {
-        this.emitter.on(eventName, handler);
-        return () => {
-            this.emitter.removeListener(eventName, handler);
-        };
-    }
+  on(eventName: 'unhandled-console-output' | 'console-output', handler: (data: string) => void);
+  public on(eventName: string, handler: (data: string) => void) {
+    this.emitter.on(eventName, handler);
+    return () => {
+      this.emitter.removeListener(eventName, handler);
+    };
+  }
 
-    private emit(eventName: 'unhandled-console-output' | 'console-output', data: string) {
-        this.emitter.emit(eventName, data);
-    }
+  private emit(eventName: 'unhandled-console-output' | 'console-output', data: string) {
+    this.emitter.emit(eventName, data);
+  }
 
-    private connect() {
-        let allResponseText = '';
-        this.client.addListener('data', (data) => {
-            let responseText = data.toString();
-            this.emit('console-output', responseText);
-            allResponseText += responseText;
+  private connect() {
+    let allResponseText = '';
+    this.client.addListener('data', (data) => {
+      let responseText = data.toString();
+      this.emit('console-output', responseText);
+      allResponseText += responseText;
 
-            //if we are not processing, immediately broadcast the latest data
-            if (!this.isProcessing) {
-                this.emit('unhandled-console-output', allResponseText);
-                allResponseText = '';
-            }
-            //we are processing. detect if we have reached a prompt. 
-            else {
-                let match;
-                //if responseText produced a prompt, return the responseText
-                if (match = /Brightscript\s+Debugger>\s+$/i.exec(allResponseText)) {
-                    //resolve the command's promise (if it cares)
-                    this.currentRequest.onComplete(allResponseText);
-                    allResponseText = '';
-                    this.currentRequest = undefined;
-                    //try to run the next request
-                    this.process();
-                }
-            }
-
-        });
-    }
-
-    /**
-     * Schedule a command to be run. Resolves with the result once the command finishes
-     * @param commandFunction
-     * @param waitForPrompt - if true, the promise will wait until we find a prompt, and return all output in between. If false, the promise will immediately resolve
-     */
-    public executeCommand(command: string, waitForPrompt: boolean) {
-        return new Promise<string>((resolve, reject) => {
-            let executeCommand = () => {
-                let commandText = `${command}\r\n`;
-                this.emit('console-output', command);
-                this.client.write(commandText);
-            };
-            this.requests.push({
-                executeCommand,
-                onComplete: resolve,
-                waitForPrompt
-            });
-            //start processing (safe to call multiple times)
-            this.process();
-        });
-    }
-
-    /**
-     * Internall request processing function
-     */
-    private async process() {
-        if (this.isProcessing || this.requests.length === 0) {
-            return;
+      //if we are not processing, immediately broadcast the latest data
+      if (!this.isProcessing) {
+        this.emit('unhandled-console-output', allResponseText);
+        allResponseText = '';
+      }
+      //we are processing. detect if we have reached a prompt. 
+      else {
+        let match;
+        //if responseText produced a prompt, return the responseText
+        if (match = /Brightscript\s+Debugger>\s+$/i.exec(allResponseText)) {
+          //resolve the command's promise (if it cares)
+          this.currentRequest.onComplete(allResponseText);
+          allResponseText = '';
+          this.currentRequest = undefined;
+          //try to run the next request
+          this.process();
         }
-        //get the oldest command
-        let nextRequest = this.requests.shift();
-        if (nextRequest.waitForPrompt) {
-            this.currentRequest = nextRequest;
-        } else {
-            //fire and forget the command
-        }
+      }
 
-        //run the request. the data listener will handle launching the next request once this one has finished processing
-        nextRequest.executeCommand();
+    });
+  }
 
-        //if the command doesn't care about the output, resolve it immediately
-        if (!nextRequest.waitForPrompt) {
-            nextRequest.onComplete(undefined);
-        }
+  /**
+   * Schedule a command to be run. Resolves with the result once the command finishes
+   * @param commandFunction
+   * @param waitForPrompt - if true, the promise will wait until we find a prompt, and return all output in between. If false, the promise will immediately resolve
+   */
+  public executeCommand(command: string, waitForPrompt: boolean) {
+    return new Promise<string>((resolve, reject) => {
+      let executeCommand = () => {
+        let commandText = `${command}\r\n`;
+        this.emit('console-output', command);
+        this.client.write(commandText);
+      };
+      this.requests.push({
+        executeCommand,
+        onComplete: resolve,
+        waitForPrompt
+      });
+      //start processing (safe to call multiple times)
+      this.process();
+    });
+  }
+
+  /**
+   * Internall request processing function
+   */
+  private async process() {
+    if (this.isProcessing || this.requests.length === 0) {
+      return;
+    }
+    //get the oldest command
+    let nextRequest = this.requests.shift();
+    if (nextRequest.waitForPrompt) {
+      this.currentRequest = nextRequest;
+    } else {
+      //fire and forget the command
     }
 
-    public destroy() {
-        this.client.removeAllListeners();
-        this.client.destroy();
-        this.client = undefined;
+    //run the request. the data listener will handle launching the next request once this one has finished processing
+    nextRequest.executeCommand();
+
+    //if the command doesn't care about the output, resolve it immediately
+    if (!nextRequest.waitForPrompt) {
+      nextRequest.onComplete(undefined);
     }
+  }
+
+  public destroy() {
+    this.client.removeAllListeners();
+    this.client.destroy();
+    this.client = undefined;
+  }
 }
 
 interface RequestPipelineRequest {
-    executeCommand: () => void;
-    onComplete: (data: string) => void;
-    waitForPrompt: boolean;
+  executeCommand: () => void;
+  onComplete: (data: string) => void;
+  waitForPrompt: boolean;
 }
 
 interface BrightScriptRuntimeError {
-    message: string;
-    errorCode: string;
+  message: string;
+  errorCode: string;
+}
+
+export interface BrightscriptDebugCompileError {
+  path: string;
+  lineNumber: number;
+  message: string;
+  errorText: string;
+  charStart: number;
+  charEnd: number;
+}
+
+
+export enum RokuAdapterStatus {
+  none = 'none',
+  compiling = 'compiling',
+  compileError = 'compileError',
+  running = 'running'
 }

--- a/src/brightScriptDebugSession.ts
+++ b/src/brightScriptDebugSession.ts
@@ -1,6 +1,6 @@
 import {
-	DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent,
-	Thread, StackFrame, Source, Breakpoint, Variable
+  DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent,
+  Thread, StackFrame, Source, Breakpoint, Variable
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import * as path from 'path';
@@ -10,518 +10,553 @@ import { RokuAdapter, EvaluateContainer } from './RokuAdapter';
 import * as findInFiles from 'find-in-files';
 import * as glob from 'glob';
 
+class CompileFailureEvent implements DebugProtocol.Event {
+  constructor(compileError: any) {
+    this.body = compileError;
+  }
+  body: any;
+  event: string;
+  seq: number;
+  type: string;
+}
+class LogOutputEvent implements DebugProtocol.Event {
+  constructor(lines: string) {
+    this.body = lines;
+    this.event = "BSLogOutputEvent";
+  }
+  body: any;
+  event: string;
+  seq: number;
+  type: string;
+}
+
 export class BrightScriptDebugSession extends DebugSession {
-	public constructor() {
-		super();
-		// this debugger uses zero-based lines and columns
-		this.setDebuggerLinesStartAt1(true);
-		this.setDebuggerColumnsStartAt1(true);
-	}
+  public constructor() {
+    super();
+    // this debugger uses zero-based lines and columns
+    this.setDebuggerLinesStartAt1(true);
+    this.setDebuggerColumnsStartAt1(true);
+  }
 
-	//set imports as class properties so they can be spied upon during testing
-	public rokuDeploy = require('roku-deploy');
+  //set imports as class properties so they can be spied upon during testing
+  public rokuDeploy = require('roku-deploy');
 
-	private rokuAdapterDeferred = defer<RokuAdapter>();
+  private rokuAdapterDeferred = defer<RokuAdapter>();
 
-	private breakpointsByClientPath: { [clientPath: string]: DebugProtocol.Breakpoint[] } = {};
-	private breakpointIdCounter = 0;
-	private evaluateRefIdLookup: { [expression: string]: number } = {};
-	private evaluateRefIdCounter = 1;
+  private breakpointsByClientPath: { [clientPath: string]: DebugProtocol.Breakpoint[] } = {};
+  private breakpointIdCounter = 0;
+  private evaluateRefIdLookup: { [expression: string]: number } = {};
+  private evaluateRefIdCounter = 1;
 
-	private variables: { [refId: number]: AugmentedVariable } = {};
+  private variables: { [refId: number]: AugmentedVariable } = {};
 
-	private rokuAdapter: RokuAdapter;
+  private rokuAdapter: RokuAdapter;
 
-	private getRokuAdapter() {
-		return this.rokuAdapterDeferred.promise;
-	}
+  private getRokuAdapter() {
+    return this.rokuAdapterDeferred.promise;
+  }
 
 
-	private launchArgs: LaunchRequestArguments;
+  private launchArgs: LaunchRequestArguments;
 
-	public get baseProjectPath() {
-		return path.normalize(this.launchArgs.rootDir);
-	}
+  public get baseProjectPath() {
+    return path.normalize(this.launchArgs.rootDir);
+  }
 
 
 	/**
 	 * The 'initialize' request is the first request called by the frontend
 	 * to interrogate the features the debug adapter provides.
 	 */
-	public initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
-		this.log('initializeRequest');
-		// since this debug adapter can accept configuration requests like 'setBreakpoint' at any time,
-		// we request them early by sending an 'initializeRequest' to the frontend.
-		// The frontend will end the configuration sequence by calling 'configurationDone' request.
-		this.sendEvent(new InitializedEvent());
+  public initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+    this.log('initializeRequest');
+    // since this debug adapter can accept configuration requests like 'setBreakpoint' at any time,
+    // we request them early by sending an 'initializeRequest' to the frontend.
+    // The frontend will end the configuration sequence by calling 'configurationDone' request.
+    this.sendEvent(new InitializedEvent());
+    response.body = response.body || {};
 
-		response.body = response.body || {};
+    // This debug adapter implements the configurationDoneRequest.
+    response.body.supportsConfigurationDoneRequest = true;
 
-		// This debug adapter implements the configurationDoneRequest.
-		response.body.supportsConfigurationDoneRequest = true;
+    // make VS Code to use 'evaluate' when hovering over source
+    response.body.supportsEvaluateForHovers = true;
 
-		// make VS Code to use 'evaluate' when hovering over source
-		response.body.supportsEvaluateForHovers = true;
+    // make VS Code to show a 'step back' button
+    response.body.supportsStepBack = false;
 
-		// make VS Code to show a 'step back' button
-		response.body.supportsStepBack = false;
-
-		this.sendResponse(response);
-	}
-
-
-	public launchRequestWasCalled = false;
-	public async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
-		this.log('launchRequest');
-		this.launchArgs = args;
-		this.launchRequestWasCalled = true;
-		let disconnect = () => { };
-
-		let error: Error;
-		console.log('Packaging and deploying to roku');
-		try {
-			//copy all project files to the staging folder
-			let stagingFolder = await this.rokuDeploy.prepublishToStaging(args);
-
-			//build a list of all files in the staging folder
-			this.loadStagingDirPaths(stagingFolder);
-
-			//convert source breakpoint paths to build paths
-			if (this.launchArgs.debugRootDir) {
-				this.convertBreakpointPaths(this.launchArgs.debugRootDir, this.launchArgs.rootDir);
-			}
-
-			//TODO add breakpoint lines to source files and then publish
-			await this.addBreakpointStatements(stagingFolder);
-
-			//convert source breakpoint paths to build paths
-			if (this.launchArgs.debugRootDir) {
-				this.convertBreakpointPaths(this.launchArgs.rootDir, this.launchArgs.debugRootDir);
-			}
-
-			//create zip package from staging folder
-			await this.rokuDeploy.zipPackage(args);
-
-			//connect to the roku debug via telnet
-			await this.connectRokuAdapter(args.host);
-
-			//pass along the console output
-			if (this.launchArgs.consoleOutput === 'full') {
-				this.rokuAdapter.on('console-output', (data) => {
-					//forward the console output
-					this.sendEvent(new OutputEvent(data, 'stdout'));
-				});
-			} else {
-				this.rokuAdapter.on('unhandled-console-output', (data) => {
-					//forward the console output
-					this.sendEvent(new OutputEvent(data, 'stdout'));
-				});
-			}
-
-			//listen for a closed connection (shut down when received)
-			this.rokuAdapter.on('close', () => {
-				error = new Error('Unable to connect to Roku. Is another device already connected?');
-			});
-
-			//watch 
-			disconnect = this.rokuAdapter.on('compile-errors', (compileErrors) => {
-				//for now, just alert the first error found
-				let compileError = compileErrors[0];
-				let clientPath = this.convertDebuggerPathToClient(compileError.path);
-				let clientLine = this.convertDebuggerLineToClientLine(compileError.path, compileError.lineNumber);
-				error = new Error(`Compile error: ${clientPath}: ${clientLine}`);
-			});
-
-			//ignore the compile error failure from within the publish
-			(args as any).failOnCompileError = false;
-			//publish the package to the target Roku  
-			await this.rokuDeploy.publish(args);
-
-			//tell the adapter adapter that the channel has been launched. 
-			await this.rokuAdapter.activate();
-
-			if (!error) {
-				console.log(`deployed to Roku@${args.host}`);
-				this.sendResponse(response);
-			} else {
-				throw error;
-			}
-		} catch (e) {
-			console.log(e);
-			this.sendErrorResponse(response, -1, e.message);
-			this.shutdown();
-			return;
-		} finally {
-			//disconnect the compile error watcher
-			disconnect();
-		}
-	}
-
-	protected sourceRequest(response: DebugProtocol.SourceResponse, args: DebugProtocol.SourceArguments) {
-		this.log('sourceRequest');
-		let old = this.sendResponse;
-		this.sendResponse = function (...args) {
-			old.apply(this, args);
-			this.sendResponse = old;
-		};
-		super.sourceRequest(response, args);
-	}
-
-	protected convertBreakpointPaths(fromRootPath: string, toRootPath: string) {
-		//convert paths to debugRootDir paths for any breakpoints set before this launch call
-		if (fromRootPath) {
-			for (let clientPath in this.breakpointsByClientPath) {
-				let debugClientPath = path.normalize(clientPath.replace(fromRootPath, toRootPath));
-				this.breakpointsByClientPath[debugClientPath] = this.breakpointsByClientPath[clientPath];
-				delete this.breakpointsByClientPath[clientPath];
-			}
-		}
-	}
+    this.sendResponse(response);
+  }
 
 
-	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments) {
-		console.log('configurationDoneRequest');
-	}
+  public launchRequestWasCalled = false;
+  public async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
+    this.log('launchRequest');
+    this.launchArgs = args;
+    this.launchRequestWasCalled = true;
+    let disconnect = () => { };
 
-	public setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments) {
-		this.log('setBreakpointsRequest');
+    let error: Error;
+    console.log('Packaging and deploying to roku');
+    try {
+      //copy all project files to the staging folder
+      let stagingFolder = await this.rokuDeploy.prepublishToStaging(args);
 
-		let clientPath = path.normalize(args.source.path);
-		console.log(clientPath);
-		//if we have a debugRootDir, convert the rootDir path to debugRootDir path
-		if (this.launchArgs && this.launchArgs.debugRootDir) {
-			clientPath = clientPath.replace(this.launchArgs.rootDir, this.launchArgs.debugRootDir);
-			console.log(clientPath);
-		}
-		let extension = path.extname(clientPath).toLowerCase();
+      //build a list of all files in the staging folder
+      this.loadStagingDirPaths(stagingFolder);
 
-		//only accept breakpoints from brightscript files
-		if (extension === '.brs') {
-			if (!this.launchRequestWasCalled) {
-				//store the breakpoints indexed by clientPath
-				this.breakpointsByClientPath[clientPath] = <any>args.breakpoints;
-				for (let b of args.breakpoints) {
-					(b as any).verified = true;
-				}
-			} else {
-				//mark the breakpoints as verified or not based on the original breakpoints
-				let verifiedBreakpoints = this.breakpointsByClientPath[clientPath];
-				outer: for (let breakpoint of args.breakpoints) {
-					for (let verifiedBreakpoint of verifiedBreakpoints) {
-						if (breakpoint.line === verifiedBreakpoint.line) {
-							(breakpoint as any).verified = true;
-							continue outer;
-						}
-					}
-					(breakpoint as any).verified = false;
-				}
-			}
-		} else {
-			//mark every breakpoint as NOT verified
-			for (let bp of args.breakpoints) {
-				(bp as any).verified = false;
-			}
-		}
+      //convert source breakpoint paths to build paths
+      if (this.launchArgs.debugRootDir) {
+        this.convertBreakpointPaths(this.launchArgs.debugRootDir, this.launchArgs.rootDir);
+      }
 
-		response.body = {
-			breakpoints: <any>args.breakpoints
-		};
-		this.sendResponse(response);
-	}
+      //TODO add breakpoint lines to source files and then publish
+      await this.addBreakpointStatements(stagingFolder);
 
-	protected async exceptionInfoRequest(response: DebugProtocol.ExceptionInfoResponse, args: DebugProtocol.ExceptionInfoArguments) {
-		this.log('exceptionInfoRequest');
-	}
+      //convert source breakpoint paths to build paths
+      if (this.launchArgs.debugRootDir) {
+        this.convertBreakpointPaths(this.launchArgs.rootDir, this.launchArgs.debugRootDir);
+      }
 
-	protected async threadsRequest(response: DebugProtocol.ThreadsResponse) {
-		this.log('threadsRequest');
-		//wait for the roku adapter to load
-		await this.getRokuAdapter();
+      //create zip package from staging folder
+      await this.rokuDeploy.zipPackage(args);
 
-		let threads = [];
+      //connect to the roku debug via telnet
+      await this.connectRokuAdapter(args.host);
 
-		//only send the threads request if we are at the debugger prompt
-		if (this.rokuAdapter.isAtDebuggerPrompt) {
-			let rokuThreads = await this.rokuAdapter.getThreads();
+      //pass along the console output
+      if (this.launchArgs.consoleOutput === 'full') {
+        this.rokuAdapter.on('console-output', (data) => {
+          //forward the console output
+          this.sendEvent(new OutputEvent(data, 'stdout'));
+          this.sendEvent(new LogOutputEvent(data));
+        });
+      } else {
+        this.rokuAdapter.on('unhandled-console-output', (data) => {
+          //forward the console output
+          this.sendEvent(new OutputEvent(data, 'stdout'));
+          this.sendEvent(new LogOutputEvent(data));
+        });
+      }
 
-			for (let thread of rokuThreads) {
-				threads.push(
-					new Thread(thread.threadId, `Thread ${thread.threadId}`)
-				);
-			}
-		} else {
-			console.log('Skipped getting threads because the RokuAdapter is not accepting input at this time.');
-		}
+      //listen for a closed connection (shut down when received)
+      this.rokuAdapter.on('close', (reason = "") => {
+        if (reason === "compileErrors") {
+          error = new Error('compileErrors');
+        } else {
+          error = new Error('Unable to connect to Roku. Is another device already connected?');
+        }
+      });
 
-		response.body = {
-			threads: threads
-		};
+      //watch 
+      // disconnect = this.rokuAdapter.on('compile-errors', (compileErrors) => {
+      this.rokuAdapter.on('compile-errors', (compileErrors) => {
+        for (let index = 0; index < compileErrors.length; index++) {
+          let compileError = compileErrors[index];
+          compileError.lineNumber = this.convertDebuggerLineToClientLine(compileError.path, compileError.lineNumber);
+          compileError.path = this.convertDebuggerPathToClient(compileError.path);
+        }
 
-		this.sendResponse(response);
-	}
+        this.sendEvent(new CompileFailureEvent(compileErrors));
+        //TODO - shot gracefull
+        this.rokuAdapter.destroy();
+        this.rokuDeploy.pressHomeButton(this.launchArgs.host);
+      });
 
-	protected async stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments) {
-		this.log('stackTraceRequest');
-		let frames = [];
+      //ignore the compile error failure from within the publish
+      (args as any).failOnCompileError = false;
+      //publish the package to the target Roku  
+      await this.rokuDeploy.publish(args);
 
-		if (this.rokuAdapter.isAtDebuggerPrompt) {
-			let stackTrace = await this.rokuAdapter.getStackTrace();
+      //tell the adapter adapter that the channel has been launched. 
+      await this.rokuAdapter.activate();
 
-			for (let debugFrame of stackTrace) {
+      if (!error) {
+        console.log(`deployed to Roku@${args.host}`);
+        this.sendResponse(response);
+      } else {
+        throw error;
+      }
+    } catch (e) {
+      console.log(e);
+      if (e.message !== "compileErrors") {
+        this.sendErrorResponse(response, -1, e.message);
+      } else {
+        //TODO make the debugger stop!
+      }
+      this.shutdown();
+      return;
+    } finally {
+      //disconnect the compile error watcher
+      disconnect();
+    }
+  }
 
-				let clientPath = this.convertDebuggerPathToClient(debugFrame.filePath);
-				let clientLineNumber = this.convertDebuggerLineToClientLine(debugFrame.filePath, debugFrame.lineNumber);
-				//the stacktrace returns function identifiers in all lower case. Try to get the actual case
-				//load the contents of the file and get the correct casing for the function identifier
-				try {
-					let fileContents = (await fsExtra.readFile(clientPath)).toString();
-					let match = new RegExp(`(?:sub|function)\\s+(${debugFrame.functionIdentifier})`, 'i').exec(fileContents);
-					if (match) {
-						debugFrame.functionIdentifier = match[1];
-					}
-				} catch (e) { }
+  protected sourceRequest(response: DebugProtocol.SourceResponse, args: DebugProtocol.SourceArguments) {
+    this.log('sourceRequest');
+    let old = this.sendResponse;
+    this.sendResponse = function (...args) {
+      old.apply(this, args);
+      this.sendResponse = old;
+    };
+    super.sourceRequest(response, args);
+  }
 
-				let frame = new StackFrame(
-					debugFrame.frameId,
-					`${debugFrame.functionIdentifier}`,
-					new Source(path.basename(clientPath), clientPath),
-					clientLineNumber,
-					1
-				);
-				frames.push(frame);
-			}
-		} else {
-			console.log('Skipped calculating stacktrace because the RokuAdapter is not accepting input at this time');
-		}
-		response.body = {
-			stackFrames: frames,
-			totalFrames: frames.length
-		};
-		this.sendResponse(response);
-	}
+  protected convertBreakpointPaths(fromRootPath: string, toRootPath: string) {
+    //convert paths to debugRootDir paths for any breakpoints set before this launch call
+    if (fromRootPath) {
+      for (let clientPath in this.breakpointsByClientPath) {
+        let debugClientPath = path.normalize(clientPath.replace(fromRootPath, toRootPath));
+        this.breakpointsByClientPath[debugClientPath] = this.breakpointsByClientPath[clientPath];
+        delete this.breakpointsByClientPath[clientPath];
+      }
+    }
+  }
 
-	protected scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments) {
-		this.log('scopesRequest');
 
-		this.sendResponse(response);
-	}
+  protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments) {
+    console.log('configurationDoneRequest');
+  }
 
-	protected async continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments) {
-		this.log('continueRequest');
-		await this.rokuAdapter.continue();
-		this.sendResponse(response);
-	}
+  public setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments) {
+    this.log('setBreakpointsRequest');
 
-	protected async pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments) {
-		this.log('pauseRequest');
-		await this.rokuAdapter.pause();
-		this.sendResponse(response);
-	}
+    let clientPath = path.normalize(args.source.path);
+    console.log(clientPath);
+    //if we have a debugRootDir, convert the rootDir path to debugRootDir path
+    if (this.launchArgs && this.launchArgs.debugRootDir) {
+      clientPath = clientPath.replace(this.launchArgs.rootDir, this.launchArgs.debugRootDir);
+      console.log(clientPath);
+    }
+    let extension = path.extname(clientPath).toLowerCase();
 
-	protected reverseContinueRequest(response: DebugProtocol.ReverseContinueResponse, args: DebugProtocol.ReverseContinueArguments) {
-		this.log('reverseContinueRequest');
-		this.sendResponse(response);
-	}
+    //only accept breakpoints from brightscript files
+    if (extension === '.brs') {
+      if (!this.launchRequestWasCalled) {
+        //store the breakpoints indexed by clientPath
+        this.breakpointsByClientPath[clientPath] = <any>args.breakpoints;
+        for (let b of args.breakpoints) {
+          (b as any).verified = true;
+        }
+      } else {
+        //mark the breakpoints as verified or not based on the original breakpoints
+        let verifiedBreakpoints = this.breakpointsByClientPath[clientPath];
+        outer: for (let breakpoint of args.breakpoints) {
+          for (let verifiedBreakpoint of verifiedBreakpoints) {
+            if (breakpoint.line === verifiedBreakpoint.line) {
+              (breakpoint as any).verified = true;
+              continue outer;
+            }
+          }
+          (breakpoint as any).verified = false;
+        }
+      }
+    } else {
+      //mark every breakpoint as NOT verified
+      for (let bp of args.breakpoints) {
+        (bp as any).verified = false;
+      }
+    }
+
+    response.body = {
+      breakpoints: <any>args.breakpoints
+    };
+    this.sendResponse(response);
+  }
+
+  protected async exceptionInfoRequest(response: DebugProtocol.ExceptionInfoResponse, args: DebugProtocol.ExceptionInfoArguments) {
+    this.log('exceptionInfoRequest');
+  }
+
+  protected async threadsRequest(response: DebugProtocol.ThreadsResponse) {
+    this.log('threadsRequest');
+    //wait for the roku adapter to load
+    await this.getRokuAdapter();
+
+    let threads = [];
+
+    //only send the threads request if we are at the debugger prompt
+    if (this.rokuAdapter.isAtDebuggerPrompt) {
+      let rokuThreads = await this.rokuAdapter.getThreads();
+
+      for (let thread of rokuThreads) {
+        threads.push(
+          new Thread(thread.threadId, `Thread ${thread.threadId}`)
+        );
+      }
+    } else {
+      console.log('Skipped getting threads because the RokuAdapter is not accepting input at this time.');
+    }
+
+    response.body = {
+      threads: threads
+    };
+
+    this.sendResponse(response);
+  }
+
+  protected async stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments) {
+    this.log('stackTraceRequest');
+    let frames = [];
+
+    if (this.rokuAdapter.isAtDebuggerPrompt) {
+      let stackTrace = await this.rokuAdapter.getStackTrace();
+
+      for (let debugFrame of stackTrace) {
+
+        let clientPath = this.convertDebuggerPathToClient(debugFrame.filePath);
+        let clientLineNumber = this.convertDebuggerLineToClientLine(debugFrame.filePath, debugFrame.lineNumber);
+        //the stacktrace returns function identifiers in all lower case. Try to get the actual case
+        //load the contents of the file and get the correct casing for the function identifier
+        try {
+          let fileContents = (await fsExtra.readFile(clientPath)).toString();
+          let match = new RegExp(`(?:sub|function)\\s+(${debugFrame.functionIdentifier})`, 'i').exec(fileContents);
+          if (match) {
+            debugFrame.functionIdentifier = match[1];
+          }
+        } catch (e) { }
+
+        let frame = new StackFrame(
+          debugFrame.frameId,
+          `${debugFrame.functionIdentifier}`,
+          new Source(path.basename(clientPath), clientPath),
+          clientLineNumber,
+          1
+        );
+        frames.push(frame);
+      }
+    } else {
+      console.log('Skipped calculating stacktrace because the RokuAdapter is not accepting input at this time');
+    }
+    response.body = {
+      stackFrames: frames,
+      totalFrames: frames.length
+    };
+    this.sendResponse(response);
+  }
+
+  protected scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments) {
+    this.log('scopesRequest');
+
+    this.sendResponse(response);
+  }
+
+  protected async continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments) {
+    this.log('continueRequest');
+    await this.rokuAdapter.continue();
+    this.sendResponse(response);
+  }
+
+  protected async pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments) {
+    this.log('pauseRequest');
+    await this.rokuAdapter.pause();
+    this.sendResponse(response);
+  }
+
+  protected reverseContinueRequest(response: DebugProtocol.ReverseContinueResponse, args: DebugProtocol.ReverseContinueArguments) {
+    this.log('reverseContinueRequest');
+    this.sendResponse(response);
+  }
 
 	/**
 	 * Clicked the "Step Over" button
 	 * @param response 
 	 * @param args 
 	 */
-	protected async nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments) {
-		this.log('nextRequest');
-		await this.rokuAdapter.stepOver();
-		this.sendResponse(response);
-	}
+  protected async nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments) {
+    this.log('nextRequest');
+    await this.rokuAdapter.stepOver();
+    this.sendResponse(response);
+  }
 
-	protected async stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments) {
-		this.log('stepInRequest');
-		await this.rokuAdapter.stepInto();
-		this.sendResponse(response);
-	}
+  protected async stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments) {
+    this.log('stepInRequest');
+    await this.rokuAdapter.stepInto();
+    this.sendResponse(response);
+  }
 
-	protected async stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments) {
-		this.log('stepOutRequest');
-		await this.rokuAdapter.stepOut();
-		this.sendResponse(response);
-	}
+  protected async stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments) {
+    this.log('stepOutRequest');
+    await this.rokuAdapter.stepOut();
+    this.sendResponse(response);
+  }
 
-	protected stepBackRequest(response: DebugProtocol.StepBackResponse, args: DebugProtocol.StepBackArguments) {
-		this.log('stepBackRequest');
+  protected stepBackRequest(response: DebugProtocol.StepBackResponse, args: DebugProtocol.StepBackArguments) {
+    this.log('stepBackRequest');
 
-		this.sendResponse(response);
-	}
+    this.sendResponse(response);
+  }
 
-	public async variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments) {
-		this.log(`variablesRequest: ${JSON.stringify(args)}`);
+  public async variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments) {
+    this.log(`variablesRequest: ${JSON.stringify(args)}`);
 
-		let childVariables: AugmentedVariable[] = [];
-		if (this.rokuAdapter.isAtDebuggerPrompt) {
-			//find the variable with this reference
-			let v = this.variables[args.variablesReference];
-			//query for child vars if we haven't done it yet.
-			if (v.childVariables.length === 0) {
-				let result = await this.rokuAdapter.getVariable(v.evaluateName);
-				let tempVar = this.getVariableFromResult(result);
-				v.childVariables = tempVar.childVariables;
-			}
-			childVariables = v.childVariables;
-		} else {
-			console.log('Skipped getting variables because the RokuAdapter is not accepting input at this time');
-		}
-		response.body = {
-			variables: childVariables
-		};
-		this.sendResponse(response);
-	}
+    let childVariables: AugmentedVariable[] = [];
+    if (this.rokuAdapter.isAtDebuggerPrompt) {
+      //find the variable with this reference
+      let v = this.variables[args.variablesReference];
+      //query for child vars if we haven't done it yet.
+      if (v.childVariables.length === 0) {
+        let result = await this.rokuAdapter.getVariable(v.evaluateName);
+        let tempVar = this.getVariableFromResult(result);
+        v.childVariables = tempVar.childVariables;
+      }
+      childVariables = v.childVariables;
+    } else {
+      console.log('Skipped getting variables because the RokuAdapter is not accepting input at this time');
+    }
+    response.body = {
+      variables: childVariables
+    };
+    this.sendResponse(response);
+  }
 
-	public async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments) {
-		if (this.rokuAdapter.isAtDebuggerPrompt) {
-			if (['hover', 'watch'].indexOf(args.context) > -1 || args.expression.toLowerCase().trim().startsWith('print ')) {
-				//if this command has the word print in front of it, remove that word
-				let expression = args.expression.replace(/^print/i, '').trim();
-				let refId = this.getEvaluateRefId(expression);
-				let v: DebugProtocol.Variable;
-				//if we already looked this item up, return it
-				if (this.variables[refId]) {
-					v = this.variables[refId];
-				} else {
-					let result = await this.rokuAdapter.getVariable(expression);
-					v = this.getVariableFromResult(result);
-				}
-				response.body = {
-					result: v.value,
-					variablesReference: v.variablesReference,
-					namedVariables: v.namedVariables || 0,
-					indexedVariables: v.indexedVariables || 0
-				};
-			}
-			//debug console typing
-			else if (args.context === 'repl') {
-				//exclude any of the standard interaction commands so we don't screw up the IDE's debugger state
-				let excludedExpressions = ['cont', 'c', 'down', 'd', 'exit', 'over', 'o', 'out', 'step', 's', 't', 'thread', 'th', 'up', 'u'];
-				if (excludedExpressions.indexOf(args.expression.toLowerCase().trim()) > -1) {
-					this.sendEvent(new OutputEvent(`Expression '${args.expression}' not permitted when debugging in VSCode`, 'stdout'));
-				} else {
-					let result = await this.rokuAdapter.evaluate(args.expression);
-					response.body = <any>{
-						result
-					};
-					// //print the output to the screen
-					// this.sendEvent(new OutputEvent(result, 'stdout'));
-				}
-			}
-		} else {
-			console.log('Skipped evaluate request because RokuAdapter is not accepting requests at this time');
-		}
+  public async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments) {
+    if (this.rokuAdapter.isAtDebuggerPrompt) {
+      if (['hover', 'watch'].indexOf(args.context) > -1 || args.expression.toLowerCase().trim().startsWith('print ')) {
+        //if this command has the word print in front of it, remove that word
+        let expression = args.expression.replace(/^print/i, '').trim();
+        let refId = this.getEvaluateRefId(expression);
+        let v: DebugProtocol.Variable;
+        //if we already looked this item up, return it
+        if (this.variables[refId]) {
+          v = this.variables[refId];
+        } else {
+          let result = await this.rokuAdapter.getVariable(expression);
+          v = this.getVariableFromResult(result);
+        }
+        response.body = {
+          result: v.value,
+          variablesReference: v.variablesReference,
+          namedVariables: v.namedVariables || 0,
+          indexedVariables: v.indexedVariables || 0
+        };
+      }
+      //debug console typing
+      else if (args.context === 'repl') {
+        //exclude any of the standard interaction commands so we don't screw up the IDE's debugger state
+        let excludedExpressions = ['cont', 'c', 'down', 'd', 'exit', 'over', 'o', 'out', 'step', 's', 't', 'thread', 'th', 'up', 'u'];
+        if (excludedExpressions.indexOf(args.expression.toLowerCase().trim()) > -1) {
+          this.sendEvent(new OutputEvent(`Expression '${args.expression}' not permitted when debugging in VSCode`, 'stdout'));
+        } else {
+          let result = await this.rokuAdapter.evaluate(args.expression);
+          response.body = <any>{
+            result
+          };
+          // //print the output to the screen
+          // this.sendEvent(new OutputEvent(result, 'stdout'));
+        }
+      }
+    } else {
+      console.log('Skipped evaluate request because RokuAdapter is not accepting requests at this time');
+    }
 
-		this.sendResponse(response);
-	}
+    this.sendResponse(response);
+  }
 
-	private loadStagingDirPaths(stagingDir: string) {
-		if (!this.stagingDirPaths) {
-			let paths = glob.sync(path.join(stagingDir, '**/*'));
-			this.stagingDirPaths = [];
-			for (let filePath of paths) {
-				//make the path relative (+1 for removing the slash)
-				let relativePath = filePath.substring(stagingDir.length + 1);
-				this.stagingDirPaths.push(relativePath);
-			}
-		}
-		return this.stagingDirPaths;
-	}
-	private stagingDirPaths: string[];
+  private loadStagingDirPaths(stagingDir: string) {
+    if (!this.stagingDirPaths) {
+      let paths = glob.sync(path.join(stagingDir, '**/*'));
+      this.stagingDirPaths = [];
+      for (let filePath of paths) {
+        //make the path relative (+1 for removing the slash)
+        let relativePath = filePath.substring(stagingDir.length + 1);
+        this.stagingDirPaths.push(relativePath);
+      }
+    }
+    return this.stagingDirPaths;
+  }
+  private stagingDirPaths: string[];
 
 	/**
 	 * Given a path from the debugger, convert it to a client path
 	 * @param debuggerPath
 	 */
-	protected convertDebuggerPathToClient(debuggerPath: string) {
-		//remove preceeding pkg: 
-		if (debuggerPath.toLowerCase().indexOf('pkg:') === 0) {
-			debuggerPath = debuggerPath.substring(4);
-			//the debugger path was truncated, so try and map it to a file in the outdir
-		} else if (debuggerPath.indexOf("...") === 0) {
-			debuggerPath = debuggerPath.substring(3);
-			//find any files from the outDir that end the same as this file
-			let results: string[] = [];
+  protected convertDebuggerPathToClient(debuggerPath: string) {
+    //remove preceeding pkg: 
+    if (debuggerPath.toLowerCase().indexOf('pkg:') === 0) {
+      debuggerPath = debuggerPath.substring(4);
+      //the debugger path was truncated, so try and map it to a file in the outdir
+    } else {
+      if (debuggerPath.indexOf("...") === 0) {
+        debuggerPath = debuggerPath.substring(3);
+      }
+      //find any files from the outDir that end the same as this file
+      let results: string[] = [];
 
-			for (let stagingPath of this.stagingDirPaths) {
-				let idx = stagingPath.indexOf(debuggerPath);
-				//if the staging path looks like the debugger path, keep it for now
-				if (idx > -1 && stagingPath.endsWith(debuggerPath)) {
-					results.push(stagingPath);
-				}
-			}
-			if (results.length === 1) {
-				//we found a single match, this is the full relative path to the file we were looking for
-				debuggerPath = results[0];
-			} else {
-				//we found multiple files with the exact same path (unlikely)...nothing we can do about it.
-			}
-		}
-		//use debugRootDir if provided, or rootDir if not provided. 
-		let rootDir = this.launchArgs.debugRootDir ? this.launchArgs.debugRootDir : this.launchArgs.rootDir;
+      for (let stagingPath of this.stagingDirPaths) {
+        let idx = stagingPath.indexOf(debuggerPath);
+        //if the staging path looks like the debugger path, keep it for now
+        if (idx > -1 && stagingPath.endsWith(debuggerPath)) {
+          results.push(stagingPath);
+        }
+      }
+      if (results.length > 0) {
+        //a wrong file, which has output is more useful than nothing!
+        debuggerPath = results[0];
+      }
+    }
+    //use debugRootDir if provided, or rootDir if not provided. 
+    let rootDir = this.launchArgs.debugRootDir ? this.launchArgs.debugRootDir : this.launchArgs.rootDir;
 
-		let clientPath = path.normalize(path.join(rootDir, debuggerPath));
-		return clientPath;
-	}
+    let clientPath = path.normalize(path.join(rootDir, debuggerPath));
+    return clientPath;
+  }
 
 	/**
 	 * Called when the host stops debugging
 	 * @param response 
 	 * @param args 
 	 */
-	protected async disconnectRequest(response: any, args: any) {
-		if (this.rokuAdapter) {
-			this.rokuAdapter.destroy();
-		}
-		//return to the home screen
-		await this.rokuDeploy.pressHomeButton(this.launchArgs.host);
-		this.sendResponse(response);
-	}
+  protected async disconnectRequest(response: any, args: any) {
+    if (this.rokuAdapter) {
+      this.rokuAdapter.destroy();
+    }
+    //return to the home screen
+    await this.rokuDeploy.pressHomeButton(this.launchArgs.host);
+    this.sendResponse(response);
+  }
 
-	private async connectRokuAdapter(host: string) {
-		//register events
-		let firstSuspend = true;
-		this.rokuAdapter = new RokuAdapter(host);
+  private async connectRokuAdapter(host: string) {
+    //register events
+    let firstSuspend = true;
+    this.rokuAdapter = new RokuAdapter(host);
 
-		//when the debugger suspends (pauses for debugger input)
-		this.rokuAdapter.on('suspend', async () => {
-			let threads = await this.rokuAdapter.getThreads();
-			let threadId = threads[0].threadId;
-			//determine if this is the "stop on entry" breakpoint
-			let isStoppedOnEntry = firstSuspend && !!this.entryBreakpoint;
+    //when the debugger suspends (pauses for debugger input)
+    this.rokuAdapter.on('suspend', async () => {
+      let threads = await this.rokuAdapter.getThreads();
+      let threadId = threads[0].threadId;
+      //determine if this is the "stop on entry" breakpoint
+      let isStoppedOnEntry = firstSuspend && !!this.entryBreakpoint;
 
-			//skip the breakpoint if this is the entry breakpoint and stopOnEntry is false
-			if (isStoppedOnEntry && !this.launchArgs.stopOnEntry) {
-				//skip the breakpoint 
-				this.rokuAdapter.continue();
-			} else {
-				this.clearState();
-				let exceptionText = '';
-				const event: StoppedEvent = new StoppedEvent(StoppedEventReason.breakpoint, threadId, exceptionText);
-				(event.body as any).allThreadsStopped = false;
-				this.sendEvent(event);
-			}
-			firstSuspend = false;
-		});
+      //skip the breakpoint if this is the entry breakpoint and stopOnEntry is false
+      if (isStoppedOnEntry && !this.launchArgs.stopOnEntry) {
+        //skip the breakpoint 
+        this.rokuAdapter.continue();
+      } else {
+        this.clearState();
+        let exceptionText = '';
+        const event: StoppedEvent = new StoppedEvent(StoppedEventReason.breakpoint, threadId, exceptionText);
+        (event.body as any).allThreadsStopped = false;
+        this.sendEvent(event);
+      }
+      firstSuspend = false;
+    });
 
-		//anytime the adapter encounters an exception on the roku,
-		this.rokuAdapter.on('runtime-error', async (exception) => {
-			let threads = await (await this.getRokuAdapter()).getThreads();
-			let threadId = threads[0].threadId;
-			this.sendEvent(new StoppedEvent('exception', threadId, exception.message));
-		});
+    //anytime the adapter encounters an exception on the roku,
+    this.rokuAdapter.on('runtime-error', async (exception) => {
+      let threads = await (await this.getRokuAdapter()).getThreads();
+      let threadId = threads[0].threadId;
+      this.sendEvent(new StoppedEvent('exception', threadId, exception.message));
+    });
 
-		// If the roku says it can't continue, we are no longer able to debug, so kill the debug session
-		this.rokuAdapter.on('cannot-continue', () => {
-			this.sendEvent(new TerminatedEvent());
-		});
-		//make the connection
-		await this.rokuAdapter.connect();
-		this.rokuAdapterDeferred.resolve(this.rokuAdapter);
-	}
+    // If the roku says it can't continue, we are no longer able to debug, so kill the debug session
+    this.rokuAdapter.on('cannot-continue', () => {
+      this.sendEvent(new TerminatedEvent());
+    });
+    //make the connection
+    await this.rokuAdapter.connect();
+    this.rokuAdapterDeferred.resolve(this.rokuAdapter);
+  }
 
 
 
@@ -529,112 +564,112 @@ export class BrightScriptDebugSession extends DebugSession {
 	 * Write "stop" lines into source code of each file for each breakpoint
 	 * @param stagingPath
 	 */
-	public async addBreakpointStatements(stagingPath: string) {
-		let promises = [];
-		let addBreakpointsToFile = async (clientPath) => {
-			let breakpoints = this.breakpointsByClientPath[clientPath];
-			let stagingFilePath: string;
-			//find the manifest file for the file
-			clientPath = path.normalize(clientPath);
-			let relativeClientPath = clientPath.toString().replace(this.baseProjectPath, '');
-			stagingFilePath = path.join(stagingPath, relativeClientPath);
-			//load the file as a string
-			let fileContents = (await fsExtra.readFile(stagingFilePath)).toString();
-			//split the file by newline
-			let lines = eol.split(fileContents);
-			for (let breakpoint of breakpoints) {
-				//since arrays are indexed by zero, but the breakpoint lines are indexed by 1, we need to subtract 1 from the breakpoint line number
-				let lineIndex = breakpoint.line - 1;
-				let line = lines[lineIndex];
-				//add a STOP statement right before this line
-				lines[lineIndex] = `STOP\n${line} `;
-			}
-			fileContents = lines.join('\n');
-			await fsExtra.writeFile(stagingFilePath, fileContents);
-		};
+  public async addBreakpointStatements(stagingPath: string) {
+    let promises = [];
+    let addBreakpointsToFile = async (clientPath) => {
+      let breakpoints = this.breakpointsByClientPath[clientPath];
+      let stagingFilePath: string;
+      //find the manifest file for the file
+      clientPath = path.normalize(clientPath);
+      let relativeClientPath = clientPath.toString().replace(this.baseProjectPath, '');
+      stagingFilePath = path.join(stagingPath, relativeClientPath);
+      //load the file as a string
+      let fileContents = (await fsExtra.readFile(stagingFilePath)).toString();
+      //split the file by newline
+      let lines = eol.split(fileContents);
+      for (let breakpoint of breakpoints) {
+        //since arrays are indexed by zero, but the breakpoint lines are indexed by 1, we need to subtract 1 from the breakpoint line number
+        let lineIndex = breakpoint.line - 1;
+        let line = lines[lineIndex];
+        //add a STOP statement right before this line
+        lines[lineIndex] = `STOP\n${line} `;
+      }
+      fileContents = lines.join('\n');
+      await fsExtra.writeFile(stagingFilePath, fileContents);
+    };
 
-		//add a breakpoint to the first line of the entry point method for consistency when debugging
-		await this.addEntryBreakpoint();
+    //add a breakpoint to the first line of the entry point method for consistency when debugging
+    await this.addEntryBreakpoint();
 
-		//add breakpoints to each client file
-		for (let clientPath in this.breakpointsByClientPath) {
-			promises.push(addBreakpointsToFile(clientPath));
-		}
-		await Promise.all(promises);
-	}
-	private entryBreakpoint: DebugProtocol.Breakpoint;
-	private async addEntryBreakpoint() {
-		let results = Object.assign(
-			{},
-			await findInFiles.find({ term: 'sub RunUserInterface\\(', flags: 'ig' }, this.baseProjectPath, /.*\.brs/),
-			await findInFiles.find({ term: 'sub main\\(', flags: 'ig' }, this.baseProjectPath, /.*\.brs/)
-		);
-		let entryPath = Object.keys(results)[0];
-		if (!entryPath) {
-			throw new Error('Unable to find an entry point. Please make sure that you have a RunUserInterface or Main sub declared in your BrightScript project');
-		}
-		let entryLine = results[entryPath].line[0];
-		let lineNumber: number;
-		//load the file contents
-		let contents = await fsExtra.readFile(entryPath);
-		let lines = eol.split(contents.toString());
-		//loop through the lines until we find the entry line
-		for (let i = 0; i < lines.length; i++) {
-			let line = lines[i];
-			if (line.indexOf(entryLine) > -1) {
-				lineNumber = i + 1;
-				break;
-			}
-		}
-		//create a breakpoint on the line BELOW this location, which is the first line of the program
-		this.entryBreakpoint = new Breakpoint(true, lineNumber + 1);
-		this.entryBreakpoint.id = this.breakpointIdCounter++;
-		(this.entryBreakpoint as any).isEntryBreakpoint = true;
-		//put this breakpoint into the list of breakpoints, in order
-		let breakpoints = this.breakpointsByClientPath[entryPath] || [];
-		breakpoints.push(this.entryBreakpoint);
-		//sort the breakpoints in order of line number
-		breakpoints.sort((a, b) => {
-			if (a.line > b.line) {
-				return 1;
-			} else if (a.line < b.line) {
-				return -1;
-			} else {
-				return 0;
-			}
-		});
+    //add breakpoints to each client file
+    for (let clientPath in this.breakpointsByClientPath) {
+      promises.push(addBreakpointsToFile(clientPath));
+    }
+    await Promise.all(promises);
+  }
+  private entryBreakpoint: DebugProtocol.Breakpoint;
+  private async addEntryBreakpoint() {
+    let results = Object.assign(
+      {},
+      await findInFiles.find({ term: 'sub RunUserInterface\\(', flags: 'ig' }, this.baseProjectPath, /.*\.brs/),
+      await findInFiles.find({ term: 'sub main\\(', flags: 'ig' }, this.baseProjectPath, /.*\.brs/)
+    );
+    let entryPath = Object.keys(results)[0];
+    if (!entryPath) {
+      throw new Error('Unable to find an entry point. Please make sure that you have a RunUserInterface or Main sub declared in your BrightScript project');
+    }
+    let entryLine = results[entryPath].line[0];
+    let lineNumber: number;
+    //load the file contents
+    let contents = await fsExtra.readFile(entryPath);
+    let lines = eol.split(contents.toString());
+    //loop through the lines until we find the entry line
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      if (line.indexOf(entryLine) > -1) {
+        lineNumber = i + 1;
+        break;
+      }
+    }
+    //create a breakpoint on the line BELOW this location, which is the first line of the program
+    this.entryBreakpoint = new Breakpoint(true, lineNumber + 1);
+    this.entryBreakpoint.id = this.breakpointIdCounter++;
+    (this.entryBreakpoint as any).isEntryBreakpoint = true;
+    //put this breakpoint into the list of breakpoints, in order
+    let breakpoints = this.breakpointsByClientPath[entryPath] || [];
+    breakpoints.push(this.entryBreakpoint);
+    //sort the breakpoints in order of line number
+    breakpoints.sort((a, b) => {
+      if (a.line > b.line) {
+        return 1;
+      } else if (a.line < b.line) {
+        return -1;
+      } else {
+        return 0;
+      }
+    });
 
-		//if the user put a breakpoint on the first line of their program, we want to keep THEIR breakpoint, not the entry breakpoint
-		let index = breakpoints.indexOf(this.entryBreakpoint);
-		let bpBefore = breakpoints[index - 1];
-		let bpAfter = breakpoints[index + 1];
-		if (
-			(bpBefore && bpBefore.line === this.entryBreakpoint.line) ||
-			(bpAfter && bpAfter.line === this.entryBreakpoint.line)
-		) {
-			breakpoints.splice(index, 1);
-			this.entryBreakpoint = undefined;
-		}
-		this.breakpointsByClientPath[entryPath] = breakpoints;
-	}
+    //if the user put a breakpoint on the first line of their program, we want to keep THEIR breakpoint, not the entry breakpoint
+    let index = breakpoints.indexOf(this.entryBreakpoint);
+    let bpBefore = breakpoints[index - 1];
+    let bpAfter = breakpoints[index + 1];
+    if (
+      (bpBefore && bpBefore.line === this.entryBreakpoint.line) ||
+      (bpAfter && bpAfter.line === this.entryBreakpoint.line)
+    ) {
+      breakpoints.splice(index, 1);
+      this.entryBreakpoint = undefined;
+    }
+    this.breakpointsByClientPath[entryPath] = breakpoints;
+  }
 
 	/**
 	 * Given a full path to a file, walk up the tree until we have found the base project path (full path to the folder containing the manifest file)
 	 * @param filePath
 	 */
-	// private async getBaseProjectPath(filePath: string) {
-	// 	//try walking up 10 levels. If we haven't found it by then, there is nothing we can do.
-	// 	let folderPath = filePath;
-	// 	for (let i = 0; i < 10; i++) {
-	// 		folderPath = path.dirname(folderPath);
-	// 		let files = await Q.nfcall(glob, path.join(folderPath, 'manifest'));
-	// 		if (files.length === 1) {
-	// 			let dir = path.dirname(files[0]);
-	// 			return path.normalize(dir);
-	// 		}
-	// 	}
-	// 	throw new Error('Unable to find base project path');
-	// }
+  // private async getBaseProjectPath(filePath: string) {
+  // 	//try walking up 10 levels. If we haven't found it by then, there is nothing we can do.
+  // 	let folderPath = filePath;
+  // 	for (let i = 0; i < 10; i++) {
+  // 		folderPath = path.dirname(folderPath);
+  // 		let files = await Q.nfcall(glob, path.join(folderPath, 'manifest'));
+  // 		if (files.length === 1) {
+  // 			let dir = path.dirname(files[0]);
+  // 			return path.normalize(dir);
+  // 		}
+  // 	}
+  // 	throw new Error('Unable to find base project path');
+  // }
 
 
 	/**
@@ -643,63 +678,63 @@ export class BrightScriptDebugSession extends DebugSession {
 	 * @param debuggerPath 
 	 * @param debuggerLineNumber 
 	 */
-	private convertDebuggerLineToClientLine(debuggerPath: string, debuggerLineNumber: number) {
-		let clientPath = this.convertDebuggerPathToClient(debuggerPath);
-		let breakpoints = this.breakpointsByClientPath[clientPath] || [];
+  private convertDebuggerLineToClientLine(debuggerPath: string, debuggerLineNumber: number) {
+    let clientPath = this.convertDebuggerPathToClient(debuggerPath);
+    let breakpoints = this.breakpointsByClientPath[clientPath] || [];
 
-		let resultLineNumber = debuggerLineNumber;
-		for (let breakpoint of breakpoints) {
-			if (breakpoint.line <= resultLineNumber) {
-				resultLineNumber--;
-			} else {
-				break;
-			}
-		}
-		return resultLineNumber;
-	}
+    let resultLineNumber = debuggerLineNumber;
+    for (let breakpoint of breakpoints) {
+      if (breakpoint.line <= resultLineNumber) {
+        resultLineNumber--;
+      } else {
+        break;
+      }
+    }
+    return resultLineNumber;
+  }
 
-	private log(...args) {
-		console.log.apply(console, args);
-	}
+  private log(...args) {
+    console.log.apply(console, args);
+  }
 
-	private getVariableFromResult(result: EvaluateContainer) {
-		let v: AugmentedVariable;
-		if (result.highLevelType === 'primative' || result.highLevelType === 'uninitialized') {
-			v = new Variable(result.name, `${result.value}`);
-		} else if (result.highLevelType === 'array') {
-			let refId = this.getEvaluateRefId(result.evaluateName);
-			v = new Variable(result.name, result.type, refId, result.children.length, 0);
-			this.variables[refId] = v;
-		} else if (result.highLevelType === 'object') {
-			let refId = this.getEvaluateRefId(result.evaluateName);
-			v = new Variable(result.name, result.type, refId, 0, result.children.length);
-			this.variables[refId] = v;
-		} else if (result.highLevelType === 'function') {
-			v = new Variable(result.name, result.value);
-		}
-		v.evaluateName = result.evaluateName;
-		if (result.children) {
-			let childVariables = [];
-			for (let childContainer of result.children) {
-				let childVar = this.getVariableFromResult(childContainer);
-				childVariables.push(childVar);
-			}
-			v.childVariables = childVariables;
-		}
-		return v;
-	}
+  private getVariableFromResult(result: EvaluateContainer) {
+    let v: AugmentedVariable;
+    if (result.highLevelType === 'primative' || result.highLevelType === 'uninitialized') {
+      v = new Variable(result.name, `${result.value}`);
+    } else if (result.highLevelType === 'array') {
+      let refId = this.getEvaluateRefId(result.evaluateName);
+      v = new Variable(result.name, result.type, refId, result.children.length, 0);
+      this.variables[refId] = v;
+    } else if (result.highLevelType === 'object') {
+      let refId = this.getEvaluateRefId(result.evaluateName);
+      v = new Variable(result.name, result.type, refId, 0, result.children.length);
+      this.variables[refId] = v;
+    } else if (result.highLevelType === 'function') {
+      v = new Variable(result.name, result.value);
+    }
+    v.evaluateName = result.evaluateName;
+    if (result.children) {
+      let childVariables = [];
+      for (let childContainer of result.children) {
+        let childVar = this.getVariableFromResult(childContainer);
+        childVariables.push(childVar);
+      }
+      v.childVariables = childVariables;
+    }
+    return v;
+  }
 
-	private getEvaluateRefId(expression: string) {
-		if (!this.evaluateRefIdLookup[expression]) {
-			this.evaluateRefIdLookup[expression] = this.evaluateRefIdCounter++;
-		}
-		return this.evaluateRefIdLookup[expression];
-	}
+  private getEvaluateRefId(expression: string) {
+    if (!this.evaluateRefIdLookup[expression]) {
+      this.evaluateRefIdLookup[expression] = this.evaluateRefIdCounter++;
+    }
+    return this.evaluateRefIdLookup[expression];
+  }
 
-	private clearState() {
-		//erase all cached variables
-		this.variables = {};
-	}
+  private clearState() {
+    //erase all cached variables
+    this.variables = {};
+  }
 
 }
 
@@ -711,56 +746,56 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	/**
 	 * The host or ip address for the target Roku
 	 */
-	host: string;
+  host: string;
 	/**
 	 * The password for the developer page on the target Roku
 	 */
-	password: string;
+  password: string;
 	/**
 	 * The root directory that contains your Roku project. This path should point to the folder containing your manifest file
 	 */
-	rootDir: string;
+  rootDir: string;
 	/**
 	 * If you have a build system, rootDir will point to the build output folder, and this path should point to the actual source folder so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change line offsets between source files and built files, otherwise debugger lines will be out of sync.
 	 */
-	debugRootDir: string;
+  debugRootDir: string;
 	/**
 	 * The folder where the output files are places during the packaging process
 	 */
-	outDir?: string;
+  outDir?: string;
 	/**
 	 * If true, stop at the first executable line of the program
 	 */
-	stopOnEntry: boolean;
+  stopOnEntry: boolean;
 	/**
 	 * Determines which console output event to listen for. Full is every console message (including the ones from the adapter). Normal excludes output initiated by the adapter
 	 */
-	consoleOutput: 'full' | 'normal';
+  consoleOutput: 'full' | 'normal';
 }
 
 interface AugmentedVariable extends DebugProtocol.Variable {
-	childVariables?: AugmentedVariable[];
+  childVariables?: AugmentedVariable[];
 }
 
 
 enum StoppedEventReason {
-	step = 'step',
-	breakpoint = 'breakpoint',
-	exception = 'exception',
-	pause = 'pause',
-	entry = 'entry'
+  step = 'step',
+  breakpoint = 'breakpoint',
+  exception = 'exception',
+  pause = 'pause',
+  entry = 'entry'
 }
 
 export function defer<T>() {
-	let resolve: (value?: T | PromiseLike<T>) => void;
-	let reject: (reason?: any) => void;
-	let promise = new Promise<T>((_resolve, _reject) => {
-		resolve = _resolve;
-		reject = _reject;
-	});
-	return {
-		promise,
-		resolve,
-		reject
-	};
+  let resolve: (value?: T | PromiseLike<T>) => void;
+  let reject: (reason?: any) => void;
+  let promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return {
+    promise,
+    resolve,
+    reject
+  };
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,20 +2,19 @@ import * as vscode from 'vscode';
 
 export function registerCommands({ subscriptions }: vscode.ExtensionContext) {
 
-    async function openFile(filename: string) {
-        let uri = vscode.Uri.file(filename);
-        let doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
-        await vscode.window.showTextDocument(doc, {preview: false});
-    }
+  async function openFile(filename: string) {
+    let uri = vscode.Uri.file(filename);
+    let doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
+    await vscode.window.showTextDocument(doc, { preview: false });
+  }
 
-    // register a command that opens a cowsay-document
   subscriptions.push(vscode.commands.registerCommand('extension.brightscript.toggleXML', async () => {
     if (vscode.window.activeTextEditor) {
       const currentDocument = vscode.window.activeTextEditor.document;
-      if (currentDocument !== undefined && currentDocument.fileName.toLowerCase().endsWith(".brs")){
+      if (currentDocument !== undefined && currentDocument.fileName.toLowerCase().endsWith(".brs")) {
         //jump to xml file
         openFile(currentDocument.fileName.substring(0, currentDocument.fileName.length - 4) + ".xml");
-      } else if (currentDocument !== undefined && currentDocument.fileName.toLowerCase().endsWith(".xml")){
+      } else if (currentDocument !== undefined && currentDocument.fileName.toLowerCase().endsWith(".xml")) {
         //jump to brs file
         openFile(currentDocument.fileName.substring(0, currentDocument.fileName.length - 4) + ".brs");
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,9 +16,11 @@ import { DefinitionRepository } from "./definitionProvider";
 import { DeclarationProvider } from "./declaration";
 import { readSymbolInformations, SymbolInformationRepository } from "./symbol";
 import { registerCommands } from './commands';
+import URI from "vscode-uri";
+import {registerDebugErrorHandler} from "./DebugErrorHandler";
 
 export function activate(context: vscode.ExtensionContext) {
-	//register the code formatter
+  //register the code formatter
   vscode.languages.registerDocumentRangeFormattingEditProvider({ language: 'brightscript', scheme: 'file' }, new Formatter());
 
   // const selector: DocumentSelector = { language: "Brightscript" };
@@ -34,6 +36,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new BrightscriptDocumentSymbolProvider()));
   context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new BrightscriptWorkspaceSymbolProvider(provider)));
   context.subscriptions.push(provider);
+  registerDebugErrorHandler();
 
   registerCommands(context);
 }

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -2,9 +2,10 @@ import * as vscode from "vscode";
 
 import { Location, SymbolInformation, TextDocument, Uri } from "vscode";
 
-import { Declaration, DeclarationProvider, readDeclarations } from "./declaration";
+import { DeclarationProvider, readDeclarations } from "./DeclarationProvider";
+import { BrightscriptDeclaration } from "./BrightscriptDeclaration";
 
-function declToSymbolInformation(uri: Uri, decl: Declaration): SymbolInformation {
+function declToSymbolInformation(uri: Uri, decl: BrightscriptDeclaration): SymbolInformation {
   return new SymbolInformation(
     decl.name,
     decl.kind,

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -15,7 +15,7 @@ function declToSymbolInformation(uri: Uri, decl: BrightscriptDeclaration): Symbo
 }
 
 export function readSymbolInformations(uri: Uri, input: string): SymbolInformation[] {
-  return readDeclarations(input).map((d) => declToSymbolInformation(uri, d));
+  return readDeclarations(uri, input).map((d) => declToSymbolInformation(uri, d));
 }
 
 export class SymbolInformationRepository {
@@ -75,7 +75,7 @@ export class SymbolInformationRepository {
   }
 
   private findInDocument(document: TextDocument, pattern: RegExp): SymbolInformation[] {
-    return readDeclarations(document.getText())
+    return readDeclarations(document.uri, document.getText())
       .filter((d) => pattern.test(d.name))
       .map((d) => declToSymbolInformation(document.uri, d));
   }

--- a/src/symbolProvider.ts
+++ b/src/symbolProvider.ts
@@ -31,7 +31,7 @@ const symbolProvider = {
     for (let line = 0; line < lineCount; line++) {
       const symbol = getSymbolForLine(document, line);
       if (symbol) {
-        console.log("got symbol " + symbol);
+        // console.log("got symbol " + symbol);
         result.push(symbol);
       }
     }


### PR DESCRIPTION
NOTE - THIS IS A WIP PR, to show what I'm doing. IT IS NOT TO BE MERGED.

This mechanism looks like it will work fine. I however, have problems/outstanding tasks:

1. extension.ts line 64, whereby, I cannot get the diagnostic to appear unless I use the uri from a document returned from the workbench. A potential workaround is to open the document, without showing it.
1. The code to get the compile errors in the debug session appears wrong - it doesn't return all of the errors from the roku telnet session
1. I'm currently not pulling in the error messages from the debug session; we need to update the regexp to report them - ideally charStart, charEnd, errorMessage and source code. It's all there and diagnostic event handler in extension is already expecting the fields to be set; the regex just needs to do the right thing.

These are all relatively quick to fix. It seems like you concur with the approach. I will also add a command to `Clear Roku Errors` - because we will only be able to clear those on launch/debug, and that might get tedious.