### PR TITLE
Included 'step' as reserved word. Added 'not searchViewletVisible' as condition for keybindings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -401,73 +401,73 @@
             {
                 "key": "Backspace",
                 "command": "extension.brightscript.pressBackButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "win+Backspace",
                 "mac": "cmd+Backspace",
                 "command": "extension.brightscript.pressBackspaceButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "Escape",
                 "command": "extension.brightscript.pressHomeButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "up",
                 "command": "extension.brightscript.pressUpButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "down",
                 "command": "extension.brightscript.pressDownButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "right",
                 "command": "extension.brightscript.pressRightButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "left",
                 "command": "extension.brightscript.pressLeftButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "Enter",
                 "command": "extension.brightscript.pressSelectButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "win+Enter",
                 "mac": "cmd+Enter",
                 "command": "extension.brightscript.pressPlayButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "win+left",
                 "mac": "cmd+left",
                 "command": "extension.brightscript.pressRevButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "win+right",
                 "mac": "cmd+right",
                 "command": "extension.brightscript.pressFwdButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "win+8",
                 "mac": "cmd+8",
                 "command": "extension.brightscript.pressStarButton",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             },
             {
                 "key": "win+k",
                 "mac": "cmd+k",
                 "command": "extension.brightscript.sendRemoteText",
-                "when": "panelFocus && !inDebugRepl && !findWidgetVisible"
+                "when": "panelFocus && !inDebugRepl && !findWidgetVisible && !searchViewletVisible"
             }
         ]
     },

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -69,7 +69,7 @@
             ]
         },
         "program_statements":{
-            "match": "(?i:\\b(if|else if|else|print|while|for each|for|((end|exit) (while|for))|end if|to|in|stop|then|sub|function|end (sub|function)|goto|return|rem|as)\\b)",
+            "match": "(?i:\\b(if|else if|else|print|while|for each|for|((end|exit) (while|for))|end if|to|step|in|stop|then|sub|function|end (sub|function)|goto|return|rem|as)\\b)",
             "name": "keyword.control.brightscript"
         },
         "operators":{


### PR DESCRIPTION
**Included 'step' as reserved word:**
    According to [Roku SDK Docs](https://sdkdocs.roku.com/display/sdkdoc/Program+Statements) `step` is an optional part of `for` loops to specify the increment after each iteration.

 **Added 'not searchViewletVisible' as condition for keybindings**
    `searchViewletVisible` is the name of the search widget if it's part of the panel instead of the sidebar. Without this condition it's practically impossible to use the search panel.