### PR TITLE
`vscode-languageserver` is required for usage as well as development

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "vscode-debugadapter": "1.27.0",
         "vscode-debugprotocol": "1.27.0",
         "vscode-languageclient": "^4.1.4",
+        "vscode-languageserver": "^4.1.3",
         "vscode-uri": "1.0.1"
     },
     "devDependencies": {
@@ -78,8 +79,7 @@
         "typescript": "^3.2.1",
         "vsce": "^1.50.0",
         "vscode": "^1.1.21",
-        "vscode-debugadapter-testsupport": "1.27.0",
-        "vscode-languageserver": "^4.1.3"
+        "vscode-debugadapter-testsupport": "1.27.0"
     },
     "main": "./out/extension",
     "activationEvents": [


### PR DESCRIPTION
When running the branch `feature/language-server`, I got errors about the `vscode-languageserver` module not being found. By moving it from `devDependencies` to dependencies`, it seems to be working correctly.