### PR TITLE
Feature/filtering log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ A VSCode extension to support Roku's BrightScript language.
 - XML goto definition support which navigates to xml component, code behind function, or brs script import (F12)
 - Method signature help (open bracket, or APPLE/Ctrl + SHIFT + SPACE)
 - Brightscript output log (which is searchable and can be colorized with a plugin like this: [https://marketplace.visualstudio.com/items?itemName=IBM.output-colorizer](https://marketplace.visualstudio.com/items?itemName=IBM.output-colorizer)
+  - Marking the output log (CTRL+L)
+  - Clearing the output log (CTRL+K), which also clears the mark indexes
+  - Filtering the output log - 3 filters are available:
+     - LogLevel (CMD|WIN+L) - example `^\[(info|warn|debug\]`
+     - Include (CMD|WIN+I)- example `NameOfSomeInterestingComponent`
+     - Exclude (CMD|WIN+X)- example `NameOfSomeNoisyComponent`
 - [Roku remote control from keyboard](#Roku-Remote-Control)
-
 
 ## Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -563,7 +563,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -2889,6 +2889,12 @@
                 }
             }
         },
+        "mocha-param": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mocha-param/-/mocha-param-2.0.0.tgz",
+            "integrity": "sha512-fSdhAkOEEqGMO6MgyBwFD1/NzXaPSELZuz8I0sAKbd4CJRd2LKJpUQKlyX4VST4mT2zxn7Yh+Ek9GNVZTvdAXQ==",
+            "dev": true
+        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3039,7 +3045,7 @@
             "dependencies": {
                 "align-text": {
                     "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                    "resolved": false,
                     "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                     "dev": true,
                     "requires": {
@@ -3050,7 +3056,7 @@
                 },
                 "amdefine": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
                     "dev": true
                 },
@@ -3071,31 +3077,31 @@
                 },
                 "archy": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
                     "dev": true
                 },
                 "arrify": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
                     "dev": true
                 },
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                     "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "resolved": false,
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
                     "requires": {
@@ -3105,7 +3111,7 @@
                 },
                 "builtin-modules": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                     "dev": true
                 },
@@ -3123,14 +3129,14 @@
                 },
                 "camelcase": {
                     "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                     "dev": true,
                     "optional": true
                 },
                 "center-align": {
                     "version": "0.1.3",
-                    "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                    "resolved": false,
                     "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                     "dev": true,
                     "optional": true,
@@ -3141,7 +3147,7 @@
                 },
                 "cliui": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "optional": true,
@@ -3153,7 +3159,7 @@
                     "dependencies": {
                         "wordwrap": {
                             "version": "0.0.2",
-                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                            "resolved": false,
                             "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                             "dev": true,
                             "optional": true
@@ -3162,19 +3168,19 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "dev": true
                 },
                 "commondir": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
                     "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "dev": true
                 },
@@ -3189,7 +3195,7 @@
                 },
                 "cross-spawn": {
                     "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
                     "dev": true,
                     "requires": {
@@ -3208,13 +3214,13 @@
                 },
                 "debug-log": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
                     "dev": true
                 },
                 "decamelize": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                     "dev": true
                 },
@@ -3244,7 +3250,7 @@
                 },
                 "execa": {
                     "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
@@ -3259,7 +3265,7 @@
                     "dependencies": {
                         "cross-spawn": {
                             "version": "5.1.0",
-                            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                             "dev": true,
                             "requires": {
@@ -3292,7 +3298,7 @@
                 },
                 "foreground-child": {
                     "version": "1.5.6",
-                    "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+                    "resolved": false,
                     "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
                     "dev": true,
                     "requires": {
@@ -3302,7 +3308,7 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true
                 },
@@ -3314,7 +3320,7 @@
                 },
                 "get-stream": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                     "dev": true
                 },
@@ -3334,13 +3340,13 @@
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 },
                 "handlebars": {
                     "version": "4.0.11",
-                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
                     "dev": true,
                     "requires": {
@@ -3352,7 +3358,7 @@
                     "dependencies": {
                         "source-map": {
                             "version": "0.4.4",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                            "resolved": false,
                             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                             "dev": true,
                             "requires": {
@@ -3375,13 +3381,13 @@
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "resolved": false,
                     "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
                     "dev": true
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "dev": true,
                     "requires": {
@@ -3391,31 +3397,31 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                     "dev": true
                 },
                 "invert-kv": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                     "dev": true
                 },
                 "is-arrayish": {
                     "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                     "dev": true
                 },
                 "is-buffer": {
                     "version": "1.1.6",
-                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                    "resolved": false,
                     "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
                     "dev": true
                 },
                 "is-builtin-module": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                     "dev": true,
                     "requires": {
@@ -3424,19 +3430,19 @@
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                     "dev": true
                 },
                 "isexe": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                     "dev": true
                 },
@@ -3504,7 +3510,7 @@
                 },
                 "kind-of": {
                     "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
@@ -3513,14 +3519,14 @@
                 },
                 "lazy-cache": {
                     "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                    "resolved": false,
                     "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                     "dev": true,
                     "optional": true
                 },
                 "lcid": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                     "dev": true,
                     "requires": {
@@ -3557,13 +3563,13 @@
                 },
                 "longest": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
                     "dev": true
                 },
                 "lru-cache": {
                     "version": "4.1.3",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+                    "resolved": false,
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
@@ -3591,13 +3597,13 @@
                 },
                 "md5-o-matic": {
                     "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
                     "dev": true
                 },
                 "mem": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                     "dev": true,
                     "requires": {
@@ -3606,7 +3612,7 @@
                 },
                 "merge-source-map": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
                     "dev": true,
                     "requires": {
@@ -3615,7 +3621,7 @@
                     "dependencies": {
                         "source-map": {
                             "version": "0.6.1",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "resolved": false,
                             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                             "dev": true
                         }
@@ -3623,13 +3629,13 @@
                 },
                 "mimic-fn": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
                     "dev": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "resolved": false,
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
@@ -3644,7 +3650,7 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
                     "requires": {
@@ -3661,13 +3667,13 @@
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 },
                 "normalize-package-data": {
                     "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
                     "dev": true,
                     "requires": {
@@ -3679,7 +3685,7 @@
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                     "dev": true,
                     "requires": {
@@ -3688,13 +3694,13 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "dev": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
@@ -3703,7 +3709,7 @@
                 },
                 "optimist": {
                     "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                     "dev": true,
                     "requires": {
@@ -3713,13 +3719,13 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true
                 },
                 "os-locale": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
@@ -3730,7 +3736,7 @@
                 },
                 "p-finally": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                     "dev": true
                 },
@@ -3788,13 +3794,13 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true
                 },
                 "path-key": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                     "dev": true
                 },
@@ -3824,7 +3830,7 @@
                 },
                 "pseudomap": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                     "dev": true
                 },
@@ -3860,19 +3866,19 @@
                 },
                 "repeat-string": {
                     "version": "1.6.1",
-                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
                     "dev": true
                 },
                 "require-directory": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                     "dev": true
                 },
                 "require-main-filename": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "dev": true
                 },
@@ -3884,7 +3890,7 @@
                 },
                 "right-align": {
                     "version": "0.1.3",
-                    "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                    "resolved": false,
                     "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                     "dev": true,
                     "optional": true,
@@ -3894,7 +3900,7 @@
                 },
                 "rimraf": {
                     "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                     "dev": true,
                     "requires": {
@@ -3909,19 +3915,19 @@
                 },
                 "semver": {
                     "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
                     "dev": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true
                 },
                 "shebang-command": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "dev": true,
                     "requires": {
@@ -3930,26 +3936,26 @@
                 },
                 "shebang-regex": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                     "dev": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true
                 },
                 "source-map": {
                     "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "resolved": false,
                     "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true,
                     "optional": true
                 },
                 "spawn-wrap": {
                     "version": "1.4.2",
-                    "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
                     "dev": true,
                     "requires": {
@@ -3963,7 +3969,7 @@
                 },
                 "spdx-correct": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
                     "dev": true,
                     "requires": {
@@ -3973,13 +3979,13 @@
                 },
                 "spdx-exceptions": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
                     "dev": true
                 },
                 "spdx-expression-parse": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
                     "dev": true,
                     "requires": {
@@ -3989,13 +3995,13 @@
                 },
                 "spdx-license-ids": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
                     "dev": true
                 },
                 "string-width": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
@@ -4020,7 +4026,7 @@
                 },
                 "strip-eof": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                     "dev": true
                 },
@@ -4047,7 +4053,7 @@
                 },
                 "uglify-js": {
                     "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "resolved": false,
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "optional": true,
@@ -4059,7 +4065,7 @@
                     "dependencies": {
                         "yargs": {
                             "version": "3.10.0",
-                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "dev": true,
                             "optional": true,
@@ -4074,7 +4080,7 @@
                 },
                 "uglify-to-browserify": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                     "dev": true,
                     "optional": true
@@ -4087,7 +4093,7 @@
                 },
                 "validate-npm-package-license": {
                     "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+                    "resolved": false,
                     "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
                     "dev": true,
                     "requires": {
@@ -4106,26 +4112,26 @@
                 },
                 "which-module": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                     "dev": true
                 },
                 "window-size": {
                     "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                     "dev": true,
                     "optional": true
                 },
                 "wordwrap": {
                     "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "resolved": false,
                     "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
                     "dev": true
                 },
                 "wrap-ansi": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                     "dev": true,
                     "requires": {
@@ -4141,7 +4147,7 @@
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "dev": true,
                             "requires": {
@@ -4150,7 +4156,7 @@
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "resolved": false,
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "dev": true,
                             "requires": {
@@ -4172,7 +4178,7 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "dev": true
                 },
@@ -4189,19 +4195,19 @@
                 },
                 "y18n": {
                     "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                     "dev": true
                 },
                 "yallist": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                     "dev": true
                 },
                 "yargs": {
                     "version": "11.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
                     "dev": true,
                     "requires": {
@@ -4221,7 +4227,7 @@
                     "dependencies": {
                         "cliui": {
                             "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                            "resolved": false,
                             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                             "dev": true,
                             "requires": {
@@ -4286,7 +4292,7 @@
                     "dependencies": {
                         "camelcase": {
                             "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                             "dev": true
                         }

--- a/package.json
+++ b/package.json
@@ -478,6 +478,21 @@
                 "key": "ctrl+k",
                 "mac": "ctrl+k",
                 "command": "extension.brightscript.clearLogOutput"
+            },
+            {
+                "key": "win+ctrl+l",
+                "mac": "cmd+ctrl+l",
+                "command": "extension.brightscript.setOutputLogLevelFilter"
+            },
+            {
+                "key": "win+ctrl+i",
+                "mac": "cmd+ctrl+i",
+                "command": "extension.brightscript.setOutputIncludeFilter"
+            },
+            {
+                "key": "win+ctrl+x",
+                "mac": "cmd+ctrl+x",
+                "command": "extension.brightscript.setOutputExcludeFilter"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "cson-parser": "^1.3.5",
         "fast-plist": "^0.1.2",
         "mocha": "^5.2.0",
+        "mocha-param": "^2.0.0",
         "nyc": "^13.1.0",
         "sinon": "^4.5.0",
         "source-map-support": "^0.5.9",

--- a/src/LogOutputManager.spec.ts
+++ b/src/LogOutputManager.spec.ts
@@ -19,8 +19,8 @@ Module.prototype.require = function hijacked(file) {
 import { LogOutputManager } from './LogOutputManager';
 
 describe('LogOutputManager ', () => {
-    let handlerMock;
-    let handler: LogOutputManager;
+    let logOutputManagerMock;
+    let logOutputManager: LogOutputManager;
     let languagesMock;
     let outputChannelMock;
     let collectionMock;
@@ -32,57 +32,128 @@ describe('LogOutputManager ', () => {
         collectionMock = sinon.mock(debugCollection);
         languagesMock = sinon.mock(vscode.languages);
         languagesMock.expects('createDiagnosticCollection').returns(debugCollection);
-
-        handler = new LogOutputManager(outputChannel, context);
-        handlerMock = sinon.mock(handler);
+        collectionMock.expects('clear');
+        logOutputManager = new LogOutputManager(outputChannel, vscode.context);
+        logOutputManagerMock = sinon.mock(logOutputManager);
     });
 
     afterEach(() => {
         outputChannelMock.restore();
         languagesMock.restore();
         collectionMock.restore();
-        handlerMock.restore();
+        logOutputManagerMock.restore();
     });
 
     it('tests onDidStartDebugSession', () => {
         collectionMock.expects('clear').once();
-        handler.onDidStartDebugSession();
+        logOutputManager.onDidStartDebugSession();
         outputChannelMock.verify();
         collectionMock.verify();
-        handlerMock.verify();
+        logOutputManagerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - BSLogOutputEvent', () => {
         outputChannelMock.expects('appendLine').once();
-        handler.onDidReceiveDebugSessionCustomEvent({ event: 'BSLogOutputEvent' });
+        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: 'BSLogOutputEvent' });
         outputChannelMock.verify();
         collectionMock.verify();
-        handlerMock.verify();
+        logOutputManagerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - error - empty', () => {
         collectionMock.expects('clear').once();
-        handler.onDidReceiveDebugSessionCustomEvent({ event: '', body: [] });
+        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: '', body: [] });
         outputChannelMock.verify();
         collectionMock.verify();
-        handlerMock.verify();
+        logOutputManagerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - error - undefined', () => {
         collectionMock.expects('clear').once();
-        handler.onDidReceiveDebugSessionCustomEvent({ event: '' });
+        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: '' });
         outputChannelMock.verify();
         collectionMock.verify();
-        handlerMock.verify();
+        logOutputManagerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - errors', () => {
         collectionMock.expects('clear').once();
-        handlerMock.expects('addDiagnosticForError').once();
+        logOutputManagerMock.expects('addDiagnosticForError').once();
         let compileErrors = [{ path: 'path1', message: 'message1' }];
-        handler.onDidReceiveDebugSessionCustomEvent({ event: '', body: compileErrors });
+        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: '', body: compileErrors });
         outputChannelMock.verify();
         collectionMock.verify();
-        handlerMock.verify();
+        logOutputManagerMock.verify();
+    });
+
+    describe('tests clearOutput', () => {
+        it('resets all expected vars', () => {
+            logOutputManager.appendLine('test1', true);
+            logOutputManager.appendLine('test2', true);
+            logOutputManager.appendLine('test3', true);
+            collectionMock.expects('clear').once();
+            outputChannelMock.expects('clear').once();
+
+            logOutputManager.clearOutput();
+
+            outputChannelMock.verify();
+            collectionMock.verify();
+        });
+
+        it('tests output indexes are cleared', () => {
+            logOutputManagerMock.expects('appendLine')
+            .withArgs('---------------------- MARK 0 ----------------------').once();
+            logOutputManagerMock.expects('appendLine')
+            .withArgs('---------------------- MARK 1 ----------------------').once();
+            logOutputManagerMock.expects('appendLine')
+            .withArgs('---------------------- MARK 2 ----------------------').once();
+            logOutputManager.markOutput();
+            logOutputManager.markOutput();
+            logOutputManager.markOutput();
+
+            logOutputManagerMock.verify();
+            collectionMock.verify();
+
+            logOutputManagerMock = sinon.mock(logOutputManager);
+            logOutputManager.clearOutput();
+            logOutputManagerMock.expects('appendLine')
+            .withArgs('---------------------- MARK 0 ----------------------').once();
+            logOutputManagerMock.expects('appendLine')
+            .withArgs('---------------------- MARK 1 ----------------------').once();
+
+            logOutputManager.markOutput();
+            logOutputManager.markOutput();
+
+            logOutputManagerMock.verify();
+            collectionMock.verify();
+
+        });
+    });
+
+    describe('tests appendLine', () => {
+        it('tests mustInclude lines are added', () => {
+            outputChannelMock.expects('appendLine')
+              .withExactArgs('test1').once();
+            logOutputManager.appendLine('test1', true);
+            outputChannelMock.verify();
+            collectionMock.verify();
+        });
+    });
+
+    describe('tests markOutput', () => {
+        it('tests outputs are added incrementally', () => {
+            logOutputManagerMock.expects('appendLine')
+              .withArgs('---------------------- MARK 0 ----------------------').once();
+            logOutputManagerMock.expects('appendLine')
+              .withArgs('---------------------- MARK 1 ----------------------').once();
+            logOutputManagerMock.expects('appendLine')
+              .withArgs('---------------------- MARK 2 ----------------------').once();
+            logOutputManager.markOutput();
+            logOutputManager.markOutput();
+            logOutputManager.markOutput();
+
+            logOutputManagerMock.verify();
+            collectionMock.verify();
+        });
     });
 });

--- a/src/LogOutputManager.spec.ts
+++ b/src/LogOutputManager.spec.ts
@@ -19,8 +19,8 @@ Module.prototype.require = function hijacked(file) {
 import { LogOutputManager } from './LogOutputManager';
 
 describe('LogOutputManager ', () => {
-    let logOutputManagerMock;
-    let logOutputManager: LogOutputManager;
+    let handlerMock;
+    let handler: LogOutputManager;
     let languagesMock;
     let outputChannelMock;
     let collectionMock;
@@ -32,128 +32,57 @@ describe('LogOutputManager ', () => {
         collectionMock = sinon.mock(debugCollection);
         languagesMock = sinon.mock(vscode.languages);
         languagesMock.expects('createDiagnosticCollection').returns(debugCollection);
-        collectionMock.expects('clear');
-        logOutputManager = new LogOutputManager(outputChannel, vscode.context);
-        logOutputManagerMock = sinon.mock(logOutputManager);
+
+        handler = new LogOutputManager(outputChannel, context);
+        handlerMock = sinon.mock(handler);
     });
 
     afterEach(() => {
         outputChannelMock.restore();
         languagesMock.restore();
         collectionMock.restore();
-        logOutputManagerMock.restore();
+        handlerMock.restore();
     });
 
     it('tests onDidStartDebugSession', () => {
         collectionMock.expects('clear').once();
-        logOutputManager.onDidStartDebugSession();
+        handler.onDidStartDebugSession();
         outputChannelMock.verify();
         collectionMock.verify();
-        logOutputManagerMock.verify();
+        handlerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - BSLogOutputEvent', () => {
         outputChannelMock.expects('appendLine').once();
-        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: 'BSLogOutputEvent' });
+        handler.onDidReceiveDebugSessionCustomEvent({ event: 'BSLogOutputEvent' });
         outputChannelMock.verify();
         collectionMock.verify();
-        logOutputManagerMock.verify();
+        handlerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - error - empty', () => {
         collectionMock.expects('clear').once();
-        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: '', body: [] });
+        handler.onDidReceiveDebugSessionCustomEvent({ event: '', body: [] });
         outputChannelMock.verify();
         collectionMock.verify();
-        logOutputManagerMock.verify();
+        handlerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - error - undefined', () => {
         collectionMock.expects('clear').once();
-        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: '' });
+        handler.onDidReceiveDebugSessionCustomEvent({ event: '' });
         outputChannelMock.verify();
         collectionMock.verify();
-        logOutputManagerMock.verify();
+        handlerMock.verify();
     });
 
     it('tests onDidReceiveDebugSessionCustomEvent - errors', () => {
         collectionMock.expects('clear').once();
-        logOutputManagerMock.expects('addDiagnosticForError').once();
+        handlerMock.expects('addDiagnosticForError').once();
         let compileErrors = [{ path: 'path1', message: 'message1' }];
-        logOutputManager.onDidReceiveDebugSessionCustomEvent({ event: '', body: compileErrors });
+        handler.onDidReceiveDebugSessionCustomEvent({ event: '', body: compileErrors });
         outputChannelMock.verify();
         collectionMock.verify();
-        logOutputManagerMock.verify();
-    });
-
-    describe('tests clearOutput', () => {
-        it('resets all expected vars', () => {
-            logOutputManager.appendLine('test1', true);
-            logOutputManager.appendLine('test2', true);
-            logOutputManager.appendLine('test3', true);
-            collectionMock.expects('clear').once();
-            outputChannelMock.expects('clear').once();
-
-            logOutputManager.clearOutput();
-
-            outputChannelMock.verify();
-            collectionMock.verify();
-        });
-
-        it('tests output indexes are cleared', () => {
-            logOutputManagerMock.expects('appendLine')
-            .withArgs('---------------------- MARK 0 ----------------------').once();
-            logOutputManagerMock.expects('appendLine')
-            .withArgs('---------------------- MARK 1 ----------------------').once();
-            logOutputManagerMock.expects('appendLine')
-            .withArgs('---------------------- MARK 2 ----------------------').once();
-            logOutputManager.markOutput();
-            logOutputManager.markOutput();
-            logOutputManager.markOutput();
-
-            logOutputManagerMock.verify();
-            collectionMock.verify();
-
-            logOutputManagerMock = sinon.mock(logOutputManager);
-            logOutputManager.clearOutput();
-            logOutputManagerMock.expects('appendLine')
-            .withArgs('---------------------- MARK 0 ----------------------').once();
-            logOutputManagerMock.expects('appendLine')
-            .withArgs('---------------------- MARK 1 ----------------------').once();
-
-            logOutputManager.markOutput();
-            logOutputManager.markOutput();
-
-            logOutputManagerMock.verify();
-            collectionMock.verify();
-
-        });
-    });
-
-    describe('tests appendLine', () => {
-        it('tests mustInclude lines are added', () => {
-            outputChannelMock.expects('appendLine')
-              .withExactArgs('test1').once();
-            logOutputManager.appendLine('test1', true);
-            outputChannelMock.verify();
-            collectionMock.verify();
-        });
-    });
-
-    describe('tests markOutput', () => {
-        it('tests outputs are added incrementally', () => {
-            logOutputManagerMock.expects('appendLine')
-              .withArgs('---------------------- MARK 0 ----------------------').once();
-            logOutputManagerMock.expects('appendLine')
-              .withArgs('---------------------- MARK 1 ----------------------').once();
-            logOutputManagerMock.expects('appendLine')
-              .withArgs('---------------------- MARK 2 ----------------------').once();
-            logOutputManager.markOutput();
-            logOutputManager.markOutput();
-            logOutputManager.markOutput();
-
-            logOutputManagerMock.verify();
-            collectionMock.verify();
-        });
+        handlerMock.verify();
     });
 });

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -3,6 +3,14 @@ import * as vscode from 'vscode';
 import { DiagnosticCollection } from 'vscode';
 
 import { BrightScriptDebugCompileError } from './RokuAdapter';
+class LogLine {
+    constructor(text, mustInclude) {
+        this.text = text;
+        this.isMustInclude = mustInclude;
+    }
+    public text: string;
+    public isMustInclude: boolean;
+}
 
 export class LogOutputManager {
     constructor(outputChannel, context) {
@@ -10,6 +18,9 @@ export class LogOutputManager {
         this.outputChannel = outputChannel;
         this.context = context;
         let subscriptions = context.subscriptions;
+        this.includeRegex = null;
+        this.logLevelRegex = null;
+        this.excludeRegex = null;
 
         subscriptions.push(vscode.commands.registerCommand('extension.brightscript.markLogOutput', () => {
             this.markOutput();
@@ -17,13 +28,46 @@ export class LogOutputManager {
         subscriptions.push(vscode.commands.registerCommand('extension.brightscript.clearLogOutput', () => {
             this.clearOutput();
         }));
+
+        subscriptions.push(vscode.commands.registerCommand('extension.brightscript.setOutputIncludeFilter', async () => {
+            let entryText: string = await vscode.window.showInputBox({
+                placeHolder: 'Enter log include regex',
+                value: this.includeRegex ? this.includeRegex.source : ''
+            });
+            if (entryText || entryText === '') {
+                this.setIncludeFilter(entryText);
+            }
+        } ));
+
+        subscriptions.push(vscode.commands.registerCommand('extension.brightscript.setOutputLogLevelFilter', async () => {
+            let entryText: string = await vscode.window.showInputBox({
+                placeHolder: 'Enter log level regex',
+                value: this.logLevelRegex ? this.logLevelRegex.source : ''
+            });
+            if (entryText || entryText === '') {
+                this.setLevelFilter(entryText);
+            }
+        } ));
+
+        subscriptions.push(vscode.commands.registerCommand('extension.brightscript.setOutputExcludeFilter', async () => {
+            let entryText: string = await vscode.window.showInputBox({
+                placeHolder: 'Enter log exclude regex',
+                value: this.excludeRegex ? this.excludeRegex.source : ''
+            });
+            if (entryText || entryText === '') {
+                this.setExcludeFilter(entryText);
+            }
+        } ));
         this.clearOutput();
 
     }
     private context: any;
-    private displayedLogLines: string[];
-    private allLogLines: string[];
+    private displayedLogLines: LogLine[];
+    private allLogLines: LogLine[];
     private markCount: number;
+    private includeRegex?: RegExp;
+    private logLevelRegex?: RegExp;
+    private excludeRegex?: RegExp;
 
     private collection: DiagnosticCollection;
     private outputChannel: vscode.OutputChannel;
@@ -101,17 +145,27 @@ export class LogOutputManager {
      * Log output methods
      */
 
-    public appendLine(line: string, mustInclude: boolean = false): void {
-        this.allLogLines.push(line);
-        if (this.matchesFilter(line) || mustInclude) {
-            this.displayedLogLines.push(line);
-            this.outputChannel.appendLine(line);
-        }
+    public appendLine(lineText: string, mustInclude: boolean = false): void {
+        let lines = lineText.split('\n');
+        lines.forEach((line) => {
+            if (line !== '') {
+                const logLine = new LogLine(line, mustInclude);
+                this.allLogLines.push(logLine);
+                if (this.matchesFilter(logLine)) {
+                    this.displayedLogLines.push(logLine);
+                    this.outputChannel.appendLine(logLine.text);
+                }
+            }
+        });
     }
 
-    public matchesFilter(body: string): boolean {
-        // TODO implement filter feature
-        return true;
+    public matchesFilter(logLine: LogLine): boolean {
+        console.log(`IS MATCHED ? ${logLine.text} ${logLine.isMustInclude} ${(!this.logLevelRegex || this.logLevelRegex.test(logLine.text))}`);
+        return (logLine.isMustInclude || (
+            (!this.logLevelRegex || this.logLevelRegex.test(logLine.text)))
+            && (!this.includeRegex || this.includeRegex.test(logLine.text)))
+            && (!this.excludeRegex || !this.excludeRegex.test(logLine.text)
+        );
     }
 
     public clearOutput(): any {
@@ -122,8 +176,35 @@ export class LogOutputManager {
         this.collection.clear();
     }
 
+    public setIncludeFilter(text: string): void {
+        this.includeRegex = text && text.trim() !== '' ? new RegExp(text, 'i') : null;
+        this.reFilterOutput();
+    }
+
+    public setExcludeFilter(text: string): void {
+        this.excludeRegex = text && text.trim() !== '' ? new RegExp(text, 'i') : null;
+        this.reFilterOutput();
+    }
+
+    public setLevelFilter(text: string): void {
+        this.logLevelRegex = text && text.trim() !== '' ? new RegExp(text, 'i') : null;
+        this.reFilterOutput();
+    }
+
+    public reFilterOutput(): void {
+        this.outputChannel.clear();
+
+        for (let i = 0; i < this.allLogLines.length - 1; i++) {
+            let logLine = this.allLogLines[i];
+            if (this.matchesFilter(logLine)) {
+                console.log(`IS MATCHED !!! ${logLine.text}`);
+                this.outputChannel.appendLine(logLine.text);
+            }
+        }
+    }
+
     public markOutput(): void {
-        this.appendLine(`---------------------- MARK ${this.markCount} ----------------------`);
+        this.appendLine(`---------------------- MARK ${this.markCount} ----------------------`, true);
         this.markCount++;
     }
 }

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -3,7 +3,8 @@ import * as vscode from 'vscode';
 import { DiagnosticCollection } from 'vscode';
 
 import { BrightScriptDebugCompileError } from './RokuAdapter';
-class LogLine {
+
+export class LogLine {
     constructor(text, mustInclude) {
         this.text = text;
         this.isMustInclude = mustInclude;
@@ -160,7 +161,6 @@ export class LogOutputManager {
     }
 
     public matchesFilter(logLine: LogLine): boolean {
-        console.log(`IS MATCHED ? ${logLine.text} ${logLine.isMustInclude} ${(!this.logLevelRegex || this.logLevelRegex.test(logLine.text))}`);
         return (logLine.isMustInclude || (
             (!this.logLevelRegex || this.logLevelRegex.test(logLine.text)))
             && (!this.includeRegex || this.includeRegex.test(logLine.text)))


### PR DESCRIPTION
Adds improved filtering in the output console, which will help developers see exactly what they need to see during intense debugging sessions.

3 Regex Filters are provided for maximum convenience (all case insensitive):

- LogLevel - example `^\[(info|warn|debug\]`
- Include - example `NameOfSomeInterestingComponent`
- Exclude - example `NameOfSomeNoisyComponent`

Currently, the filters are set by using hotkeys : CMD|WIN+L for level, CMD|WIN+i for include, and CMD|WIN+x for exclude.

The last entered value is remembered - an empty value is presumed to disable the filtering.

I hope someone might build on this to perhaps add a UI/panel/some other better mechanism for managing the filters; but I've been using this for a few days, and it's already been very helpful as it is on 2 huge apps I work on.