### PR TITLE
Bubble launch failure errors to top level so they can show in UI. (Fixes #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [Unreleased]
+ - Fixed bug that was not showing an error message when a deployment failed.
+
 ## [1.6.0] - 2019-01-15
  - Prevent adding entry breakpoint when `stopOnEntry` is `false` in launch.json.
  - Upgraded to roku-deploy@2.0.0-beta2 which fixes some regression issues introduced in 1.0.0

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -111,8 +111,10 @@ export class BrightScriptDebugSession extends DebugSession {
         };
 
         let error: Error;
-        console.log('Packaging and deploying to roku');
+        this.log('Packaging and deploying to roku');
         try {
+
+            this.sendDebugLogLine('Moving selected files to staging area');
             //copy all project files to the staging folder
             let stagingFolder = await this.rokuDeploy.prepublishToStaging(args);
 
@@ -124,7 +126,8 @@ export class BrightScriptDebugSession extends DebugSession {
                 this.convertBreakpointPaths(this.launchArgs.debugRootDir, this.launchArgs.rootDir);
             }
 
-            //TODO add breakpoint lines to source files and then publish
+            //add breakpoint lines to source files and then publish
+            this.sendDebugLogLine('Adding stop statements for active breakpoints');
             await this.addBreakpointStatements(stagingFolder);
 
             //convert source breakpoint paths to build paths
@@ -133,8 +136,10 @@ export class BrightScriptDebugSession extends DebugSession {
             }
 
             //create zip package from staging folder
+            this.sendDebugLogLine('Creating zip archive from project sources');
             await this.rokuDeploy.zipPackage(args);
 
+            this.sendDebugLogLine('Connecting to Roku via telnet');
             //connect to the roku debug via telnet
             await this.connectRokuAdapter(args.host);
 
@@ -192,10 +197,12 @@ export class BrightScriptDebugSession extends DebugSession {
             }
         } catch (e) {
             console.log(e);
+            //if the message is anything other than compile errors, we want to display the error
             if (e.message !== 'compileErrors') {
-                this.sendErrorResponse(response, -1, e.message);
-            } else {
                 //TODO make the debugger stop!
+                this.sendDebugLogLine('Encountered an issue during the publish process');
+                this.sendDebugLogLine(e.message);
+                this.sendErrorResponse(response, -1, e.message);
             }
             this.shutdown();
             return;
@@ -711,6 +718,10 @@ export class BrightScriptDebugSession extends DebugSession {
 
     private log(...args) {
         console.log.apply(console, args);
+    }
+
+    private sendDebugLogLine(message: string) {
+        this.sendEvent(new LogOutputEvent(`debugger: ${message}`));
     }
 
     private getVariableFromResult(result: EvaluateContainer) {


### PR DESCRIPTION
Certain launch errors are not properly captured in the promise or async/await chains, and as such, the debugger doesn't stop, or dies without a good error. This PR fixes many of these issues by doing a better job passing the errors up the chain, and showing a proper error message.
Fixes #69 