### PR TITLE
wip of bypassing bogus breakpoints

### DIFF
--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -19,6 +19,8 @@ export class RokuAdapter {
         this.compilingLines = [];
         this.lastUnhandledDataTime = 0;
         this.maxDataMsWhenCompiling = 500;
+        this.debugStartRegex = new RegExp('BrightScript Micro Debugger\.', 'ig');
+        this.debugEndRegex = new RegExp('Brightscript Debugger>', 'ig');
     }
 
     private status: RokuAdapterStatus;
@@ -30,6 +32,12 @@ export class RokuAdapter {
     private lastUnhandledDataTime: number;
     private maxDataMsWhenCompiling: number;
     private compileErrorTimer: any;
+    private isContinuedOnce: boolean;
+    private isNextBreakpointSkipped: boolean = false;
+    private isInMicroDebugger: boolean;
+    private currentMicroDebuggerText: string;
+    private debugStartRegex: RegExp;
+    private debugEndRegex: RegExp;
 
     private cache = {};
 
@@ -122,11 +130,43 @@ export class RokuAdapter {
         });
     }
 
+    public processBreakpoints(text): string | null {
+        // console.log(lines);
+        let newLines = eol.split(text);
+        newLines.forEach((line) => {
+            console.log('Running processing line; ', line);
+            if (line.match(this.debugStartRegex)) {
+                console.log('start MicroDebugger block');
+                this.isInMicroDebugger = true;
+                this.currentMicroDebuggerText = '';
+                this.isNextBreakpointSkipped = false;
+                text = 'Pausing for a breakpoint...';
+            } else if (this.isInMicroDebugger && line.match(this.debugEndRegex)) {
+                console.log('ended MicroDebugger block');
+                this.isInMicroDebugger = false;
+                if (this.isNextBreakpointSkipped) {
+                    text += '\n**Was a bogus breakpoint** Skipping!\n';
+                } else {
+                    text = null; //this.currentMicroDebuggerText;
+                }
+            } else if (this.isInMicroDebugger) {
+                this.currentMicroDebuggerText += line + '\n';
+                if (line.startsWith('Break in ')) {
+                    console.log('this block is a break: skipping it');
+                    this.isNextBreakpointSkipped = true;
+                }
+                text = null;
+            }
+        });
+        return text;
+    }
+
     /**
      * Connect to the telnet session. This should be called before the channel is launched.
      */
     public async connect() {
         let deferred = defer();
+
         try {
             //force roku to return to home screen. This gives the roku adapter some security in knowing new messages won't be appearing during initialization
             await rokuDeploy.pressHomeButton(this.host);
@@ -155,7 +195,10 @@ export class RokuAdapter {
 
             //forward all raw counsole output
             this.requestPipeline.on('console-output', (output) => {
-                this.emit('console-output', output);
+                const text = this.processBreakpoints(output);
+                if (text) {
+                    this.emit('console-output', text);
+                }
             });
 
             //listen for any console output that was not handled by other methods in the adapter
@@ -169,7 +212,10 @@ export class RokuAdapter {
                 }
 
                 //forward all unhandled console output
-                this.emit('unhandled-console-output', responseText);
+                const text = this.processBreakpoints(responseText);
+                if (text) {
+                    this.emit('unhandled-console-output', text);
+                }
 
                 this.processUnhandledLines(responseText);
                 let match;
@@ -189,11 +235,18 @@ export class RokuAdapter {
                     //watch for debugger prompt output
                     if (match = /Brightscript\s*Debugger>\s*$/i.exec(responseText.trim())) {
                         //if we are activated AND this is the first time seeing the debugger prompt since a continue/step action
-                        if (this.isActivated && this.isAtDebuggerPrompt === false) {
-                            this.isAtDebuggerPrompt = true;
-                            this.emit('suspend');
+                        if (this.isNextBreakpointSkipped) {
+                            console.log('this breakpoint is flagged to be skipped');
+                            this.isInMicroDebugger = false;
+                            this.isNextBreakpointSkipped = false;
+                            this.requestPipeline.executeCommand('c', false, false);
                         } else {
-                            this.isAtDebuggerPrompt = true;
+                            if (this.isActivated && this.isAtDebuggerPrompt === false) {
+                                this.isAtDebuggerPrompt = true;
+                                this.emit('suspend');
+                            } else {
+                                this.isAtDebuggerPrompt = true;
+                            }
                         }
                     } else {
                         this.isAtDebuggerPrompt = false;
@@ -525,6 +578,7 @@ export class RokuAdapter {
      */
     public continue() {
         this.clearCache();
+        this.isContinuedOnce = true;
         return this.requestPipeline.executeCommand('c', false);
     }
 
@@ -941,10 +995,12 @@ export class RequestPipeline {
     constructor(
         private client: Socket
     ) {
+        this.debuggerLineRegex = /Brightscript\s+Debugger>\s*$/i;
         this.connect();
     }
 
     private requests: RequestPipelineRequest[] = [];
+    private debuggerLineRegex: RegExp;
 
     private get isProcessing() {
         return this.currentRequest !== undefined;
@@ -980,7 +1036,7 @@ export class RequestPipeline {
             } else {
                 let match;
                 //if responseText produced a prompt, return the responseText
-                if (match = /Brightscript\s+Debugger>\s*$/i.exec(allResponseText.trim())) {
+                if (match = this.debuggerLineRegex.exec(allResponseText.trim())) {
                     //resolve the command's promise (if it cares)
                     this.currentRequest.onComplete(allResponseText);
                     allResponseText = '';
@@ -998,12 +1054,14 @@ export class RequestPipeline {
      * @param commandFunction
      * @param waitForPrompt - if true, the promise will wait until we find a prompt, and return all output in between. If false, the promise will immediately resolve
      */
-    public executeCommand(command: string, waitForPrompt: boolean) {
+    public executeCommand(command: string, waitForPrompt: boolean, silent: boolean = false) {
         console.debug(`Execute command (and ${waitForPrompt ? 'do' : 'do not'} wait for prompt):`, command);
         return new Promise<string>((resolve, reject) => {
             let executeCommand = () => {
                 let commandText = `${command}\r\n`;
-                this.emit('console-output', command);
+                if (!silent) {
+                    this.emit('console-output', command);
+                }
                 this.client.write(commandText);
             };
             this.requests.push({


### PR DESCRIPTION
this is a POC of bypassing fake breakpoints.

brighscript microprocessor stops on "Break in" scnenarios, which is not just undesirable; but can also lead to crashes. It seems the longer one stays on one of these "Break in" pauses, the more likely that the stack's memory will become corrupted, and app crash - furthermore, more and more of these Break In interrupts get generated.

This solution detects this and instantly skips them.

I did try several things to avoid printing out stack trace info, and to even change the output; but to no avail. I suspect the LogOutputManager, might be the safest place to filter out these kind of lines, as the lower level RokuAdapter, and BrighscriptDebugSession tend to get into all kinds of race conditions, and even start producing garbled output, when I attempt to play with the log output.