### PR TITLE
Close any leftover debugging threads before side loading

### DIFF
--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -161,6 +161,8 @@ export class BrightScriptDebugSession extends DebugSession {
             //connect to the roku debug via telnet
             await this.connectRokuAdapter(args.host);
 
+            await this.rokuAdapter.exitActiveBrightscriptDebugger();
+
             //pass along the console output
             if (this.launchArgs.consoleOutput === 'full') {
                 this.rokuAdapter.on('console-output', (data) => {

--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -879,8 +879,9 @@ export class RokuAdapter {
     /**
      * Disconnect from the telnet session and unset all objects
      */
-    public destroy() {
+    public async destroy() {
         if (this.requestPipeline) {
+            await this.exitActiveBrightscriptDebugger();
             this.requestPipeline.destroy();
         }
 
@@ -890,6 +891,21 @@ export class RokuAdapter {
             this.emitter.removeAllListeners();
         }
         this.emitter = undefined;
+    }
+
+    /**
+     * Make sure any active Brightscript Debugger threads are exited
+     */
+    public async exitActiveBrightscriptDebugger() {
+        if (this.requestPipeline) {
+            let commandsExecuted = 0;
+            do {
+                let data = await this.requestPipeline.executeCommand(`exit`, false);
+                // This seems to work without the delay but I wonder about slower devices
+                // await setTimeout[Object.getOwnPropertySymbols(setTimeout)[0]](100);
+                commandsExecuted ++;
+            } while (commandsExecuted < 10);
+        }
     }
 }
 


### PR DESCRIPTION
This attempts to close any leftover debugging threads before side loading and when stopping the debug adapter.