### PR TITLE
Feature/skip onbreak false breakpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -491,7 +491,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -902,7 +902,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -1197,7 +1197,7 @@
         },
         "doctrine": {
             "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+            "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
             "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
             "dev": true,
             "requires": {
@@ -2645,7 +2645,7 @@
                 },
                 "commander": {
                     "version": "2.15.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
                     "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
@@ -2870,13 +2870,13 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
                 "append-transform": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
                     "dev": true,
                     "requires": {
@@ -2885,25 +2885,25 @@
                 },
                 "archy": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
                     "dev": true
                 },
                 "arrify": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
                     "dev": true
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                     "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "resolved": false,
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
                     "requires": {
@@ -2931,25 +2931,25 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "dev": true
                 },
                 "commondir": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
                     "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "dev": true
                 },
                 "convert-source-map": {
                     "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
                     "dev": true,
                     "requires": {
@@ -2958,7 +2958,7 @@
                 },
                 "cross-spawn": {
                     "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
                     "dev": true,
                     "requires": {
@@ -2983,13 +2983,13 @@
                 },
                 "decamelize": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                     "dev": true
                 },
                 "default-require-extensions": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
                     "dev": true,
                     "requires": {
@@ -2998,7 +2998,7 @@
                 },
                 "error-ex": {
                     "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
                     "dev": true,
                     "requires": {
@@ -3007,7 +3007,7 @@
                 },
                 "es6-error": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
                     "dev": true
                 },
@@ -3041,7 +3041,7 @@
                 },
                 "find-cache-dir": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
                     "dev": true,
                     "requires": {
@@ -3052,7 +3052,7 @@
                 },
                 "find-up": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
@@ -3061,7 +3061,7 @@
                 },
                 "foreground-child": {
                     "version": "1.5.6",
-                    "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+                    "resolved": false,
                     "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
                     "dev": true,
                     "requires": {
@@ -3071,13 +3071,13 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true
                 },
                 "get-caller-file": {
                     "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+                    "resolved": false,
                     "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
                     "dev": true
                 },
@@ -3089,7 +3089,7 @@
                 },
                 "glob": {
                     "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "resolved": false,
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
@@ -3109,25 +3109,25 @@
                 },
                 "has-flag": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
                 "hosted-git-info": {
                     "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+                    "resolved": false,
                     "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
                     "dev": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "resolved": false,
                     "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
                     "dev": true
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "dev": true,
                     "requires": {
@@ -3137,7 +3137,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "resolved": false,
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                     "dev": true
                 },
@@ -3149,7 +3149,7 @@
                 },
                 "is-arrayish": {
                     "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                     "dev": true
                 },
@@ -3164,19 +3164,19 @@
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                     "dev": true
                 },
                 "isexe": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                     "dev": true
                 },
@@ -3221,7 +3221,7 @@
                     "dependencies": {
                         "source-map": {
                             "version": "0.6.1",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "resolved": false,
                             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                             "dev": true
                         }
@@ -3238,7 +3238,7 @@
                 },
                 "json-parse-better-errors": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
                     "dev": true
                 },
@@ -3253,7 +3253,7 @@
                 },
                 "load-json-file": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
@@ -3265,7 +3265,7 @@
                 },
                 "locate-path": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
@@ -3275,7 +3275,7 @@
                 },
                 "lodash.flattendeep": {
                     "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
                     "dev": true
                 },
@@ -3291,7 +3291,7 @@
                 },
                 "make-dir": {
                     "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
                     "requires": {
@@ -3324,7 +3324,7 @@
                 },
                 "merge-source-map": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
                     "dev": true,
                     "requires": {
@@ -3333,7 +3333,7 @@
                     "dependencies": {
                         "source-map": {
                             "version": "0.6.1",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "resolved": false,
                             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                             "dev": true
                         }
@@ -3341,13 +3341,13 @@
                 },
                 "mimic-fn": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
                     "dev": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "resolved": false,
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
@@ -3356,7 +3356,7 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
                     "requires": {
@@ -3365,7 +3365,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "0.0.8",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                            "resolved": false,
                             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                             "dev": true
                         }
@@ -3391,7 +3391,7 @@
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                     "dev": true,
                     "requires": {
@@ -3400,13 +3400,13 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "dev": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
@@ -3415,7 +3415,7 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true
                 },
@@ -3432,7 +3432,7 @@
                 },
                 "p-finally": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                     "dev": true
                 },
@@ -3447,7 +3447,7 @@
                 },
                 "p-locate": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "dev": true,
                     "requires": {
@@ -3456,7 +3456,7 @@
                 },
                 "p-try": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
                     "dev": true
                 },
@@ -3474,7 +3474,7 @@
                 },
                 "parse-json": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
@@ -3484,25 +3484,25 @@
                 },
                 "path-exists": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true
                 },
                 "path-key": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                     "dev": true
                 },
                 "path-type": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
@@ -3511,13 +3511,13 @@
                 },
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 },
                 "pkg-dir": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                     "dev": true,
                     "requires": {
@@ -3526,13 +3526,13 @@
                 },
                 "pseudomap": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                     "dev": true
                 },
                 "read-pkg": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
@@ -3543,7 +3543,7 @@
                 },
                 "read-pkg-up": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
                     "dev": true,
                     "requires": {
@@ -3553,7 +3553,7 @@
                 },
                 "release-zalgo": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
                     "dev": true,
                     "requires": {
@@ -3562,19 +3562,19 @@
                 },
                 "require-directory": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                     "dev": true
                 },
                 "require-main-filename": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "resolved": false,
                     "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "dev": true
                 },
                 "resolve-from": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                     "dev": true
                 },
@@ -3589,7 +3589,7 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                     "dev": true
                 },
@@ -3601,13 +3601,13 @@
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true
                 },
                 "shebang-command": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "dev": true,
                     "requires": {
@@ -3616,19 +3616,19 @@
                 },
                 "shebang-regex": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                     "dev": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true
                 },
                 "spawn-wrap": {
                     "version": "1.4.2",
-                    "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
                     "dev": true,
                     "requires": {
@@ -3658,7 +3658,7 @@
                 },
                 "spdx-expression-parse": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
                     "dev": true,
                     "requires": {
@@ -3674,7 +3674,7 @@
                 },
                 "string-width": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "resolved": false,
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
@@ -3684,7 +3684,7 @@
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
@@ -3693,13 +3693,13 @@
                 },
                 "strip-bom": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
                     "dev": true
                 },
                 "strip-eof": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                     "dev": true
                 },
@@ -3726,7 +3726,7 @@
                 },
                 "uuid": {
                     "version": "3.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "resolved": false,
                     "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
                     "dev": true
                 },
@@ -3742,7 +3742,7 @@
                 },
                 "which": {
                     "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "resolved": false,
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "dev": true,
                     "requires": {
@@ -3751,13 +3751,13 @@
                 },
                 "which-module": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                     "dev": true
                 },
                 "wrap-ansi": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                     "dev": true,
                     "requires": {
@@ -3767,13 +3767,13 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "resolved": false,
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                             "dev": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "resolved": false,
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "dev": true,
                             "requires": {
@@ -3782,7 +3782,7 @@
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "resolved": false,
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "dev": true,
                             "requires": {
@@ -3793,7 +3793,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "resolved": false,
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "dev": true,
                             "requires": {
@@ -3804,7 +3804,7 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "dev": true
                 },
@@ -3827,7 +3827,7 @@
                 },
                 "yallist": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "resolved": false,
                     "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                     "dev": true
                 },
@@ -4432,7 +4432,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "requires": {
                 "ret": "~0.1.10"

--- a/package.json
+++ b/package.json
@@ -238,7 +238,8 @@
                         "stopOnEntry": true,
                         "host": "${promptForHost}",
                         "password": "${promptForPassword}",
-                        "rootDir": "${workspaceFolder}"
+                        "rootDir": "${workspaceFolder}",
+                        "skipBogusBreakpoints": false
                     }
                 ],
                 "configurationSnippets": [
@@ -252,7 +253,8 @@
                             "stopOnEntry": true,
                             "host": "${promptForHost}",
                             "password": "${promptForPassword}",
-                            "rootDir": "^\"\\${workspaceFolder}\""
+                            "rootDir": "^\"\\${workspaceFolder}\"",
+                            "skipBogusBreakpoints": false
                         }
                     }
                 ]
@@ -353,6 +355,18 @@
                     "type": "string",
                     "default": "${promptForHost}",
                     "description": "IP address of the roku to remotely control",
+                    "scope": "resource"
+                },
+                "brightscript.debug.skipBogusBreakpoints": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Multi run-loop SG apps (i.e with tasks) can cause the breakpoint debugger to crash when they stop on bogus 'in break' breakpoints. If set to true, the extension will automatically continiue on detecting these kinds of breakpoints.",
+                    "scope": "resource"
+                },
+                "brightscript.output.doNotIncludeStackTracesInLogOutput": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, will not print stack trace or breakpoint info in the log output.",
                     "scope": "resource"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -226,6 +226,11 @@
                                         }
                                     ]
                                 }
+                            },
+                            "enableDebuggerAutoRecovery": {
+                                "type": "boolean",
+                                "description": "Enables automatic continue when hitting an incorrect 'break in' breapoint, which are produced by a bug in the roku microdebugger, mishandling multiple runloops. This flag will enable you to recover in most cases - wait until the skipping bogus breakpoint messages have all stopped before continuing to use your app, for best results.",
+                                "default": true
                             }
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
                     "description": "Multi run-loop SG apps (i.e with tasks) can cause the breakpoint debugger to crash when they stop on bogus 'in break' breakpoints. If set to true, the extension will automatically continiue on detecting these kinds of breakpoints.",
                     "scope": "resource"
                 },
-                "brightscript.output.includeStackTracesInLogOutput": {
+                "brightscript.output.includeStackTraces": {
                     "type": "boolean",
                     "default": true,
                     "description": "If set to true, will print stack trace or breakpoint info in the log output. Set to false to avoid noisy logs - you'll still get the traces in the debug console, in any case.",

--- a/package.json
+++ b/package.json
@@ -363,10 +363,10 @@
                     "description": "Multi run-loop SG apps (i.e with tasks) can cause the breakpoint debugger to crash when they stop on bogus 'in break' breakpoints. If set to true, the extension will automatically continiue on detecting these kinds of breakpoints.",
                     "scope": "resource"
                 },
-                "brightscript.output.doNotIncludeStackTracesInLogOutput": {
+                "brightscript.output.includeStackTracesInLogOutput": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "If set to true, will not print stack trace or breakpoint info in the log output.",
+                    "default": true,
+                    "description": "If set to true, will print stack trace or breakpoint info in the log output. Set to false to avoid noisy logs - you'll still get the traces in the debug console, in any case.",
                     "scope": "resource"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
                         "host": "${promptForHost}",
                         "password": "${promptForPassword}",
                         "rootDir": "${workspaceFolder}",
-                        "skipBogusBreakpoints": false
+                        "enableDebuggerAutoRecovery": false
                     }
                 ],
                 "configurationSnippets": [
@@ -254,7 +254,7 @@
                             "host": "${promptForHost}",
                             "password": "${promptForPassword}",
                             "rootDir": "^\"\\${workspaceFolder}\"",
-                            "skipBogusBreakpoints": false
+                            "enableDebuggerAutoRecovery": false
                         }
                     }
                 ]
@@ -355,12 +355,6 @@
                     "type": "string",
                     "default": "${promptForHost}",
                     "description": "IP address of the roku to remotely control",
-                    "scope": "resource"
-                },
-                "brightscript.debug.skipBogusBreakpoints": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Multi run-loop SG apps (i.e with tasks) can cause the breakpoint debugger to crash when they stop on bogus 'in break' breakpoints. If set to true, the extension will automatically continiue on detecting these kinds of breakpoints.",
                     "scope": "resource"
                 },
                 "brightscript.output.includeStackTraces": {

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -602,7 +602,7 @@ export class BrightScriptDebugSession extends DebugSession {
             this.sendEvent(new TerminatedEvent());
         });
         //make the connection
-        await this.rokuAdapter.connect();
+        await this.rokuAdapter.connect(this.launchArgs.skipBogusBreakpoints);
         this.rokuAdapterDeferred.resolve(this.rokuAdapter);
     }
 
@@ -843,6 +843,10 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
      * Enables automatic population of the debug variable panel on a breakpoint or runtime errors.
      */
     enableVariablesPanel: boolean;
+    /**
+     * If true, will attempt to skip false breakpoints created by the micro debugger, which are particularly prevalent for SG apps with multiple run loops.
+     */
+    skipBogusBreakpoints: boolean;
 }
 
 interface AugmentedVariable extends DebugProtocol.Variable {

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -602,7 +602,7 @@ export class BrightScriptDebugSession extends DebugSession {
             this.sendEvent(new TerminatedEvent());
         });
         //make the connection
-        await this.rokuAdapter.connect(this.launchArgs.skipBogusBreakpoints);
+        await this.rokuAdapter.connect(this.launchArgs.enableDebuggerAutoRecovery);
         this.rokuAdapterDeferred.resolve(this.rokuAdapter);
     }
 
@@ -846,7 +846,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     /**
      * If true, will attempt to skip false breakpoints created by the micro debugger, which are particularly prevalent for SG apps with multiple run loops.
      */
-    skipBogusBreakpoints: boolean;
+    enableDebuggerAutoRecovery: boolean;
 }
 
 interface AugmentedVariable extends DebugProtocol.Variable {

--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -25,7 +25,6 @@ Module.prototype.require = function hijacked(file) {
     }
 };
 
-
 import { BrightScriptDebugConfigurationProvider } from './DebugConfigurationProvider';
 let configProvider: BrightScriptDebugConfigurationProvider;
 
@@ -57,7 +56,7 @@ describe('BrightScriptConfigurationProvider', () => {
                 type: 'brightscript',
                 envFile: '${workspaceFolder}/.env',
                 password: '${env:ROKU_PASSWORD}',
-                skipBogusBreakpoints: false
+                enableDebuggerAutoRecovery: false
             });
             expect(config.password).to.equal('pass1234');
             expect(stub.called).to.be.true;

--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -1,12 +1,34 @@
 /* tslint:disable:no-unused-expression */
+/* tslint:disable:no-var-requires */
 import { assert, expect } from 'chai';
 import * as sinonImport from 'sinon';
 
-import { BrightScriptDebugConfigurationProvider } from './DebugConfigurationProvider';
-
 let sinon: sinonImport.SinonSandbox;
-let configProvider: BrightScriptDebugConfigurationProvider;
 let c: any;
+let Module = require('module');
+
+import { vscode } from './mockVscode.spec';
+
+let commandsMock;
+
+//override the "require" call to mock certain items
+const { require: oldRequire } = Module.prototype;
+Module.prototype.require = function hijacked(file) {
+    if (file === 'vscode') {
+        return vscode;
+    } else if (file === './BrightScriptCommands') {
+        let command = { registerCommands: () => { } };
+        commandsMock = sinon.mock(command);
+        return { getBrightScriptCommandsInstance: () => command };
+    } else {
+        return oldRequire.apply(this, arguments);
+    }
+};
+
+
+import { BrightScriptDebugConfigurationProvider } from './DebugConfigurationProvider';
+let configProvider: BrightScriptDebugConfigurationProvider;
+
 beforeEach(() => {
     let context = {
         workspaceState: {
@@ -34,7 +56,8 @@ describe('BrightScriptConfigurationProvider', () => {
                 host: '127.0.0.1',
                 type: 'brightscript',
                 envFile: '${workspaceFolder}/.env',
-                password: '${env:ROKU_PASSWORD}'
+                password: '${env:ROKU_PASSWORD}',
+                skipBogusBreakpoints: false
             });
             expect(config.password).to.equal('pass1234');
             expect(stub.called).to.be.true;

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -47,7 +47,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         config.clearOutputOnLaunch = config.clearOutputOnLaunch === true ? true : false;
         config.selectOutputOnLogMessage = config.selectOutputOnLogMessage === true ? true : false;
         config.enableVariablesPanel = 'enableVariablesPanel' in config ? config.enableVariablesPanel : true;
-        config.skipBogusBreakpoints = config.skipBogusBreakpoints === true ? true : (settings.debug || {}).skipBogusBreakpoints;
+        config.enableDebuggerAutoRecovery = config.enableDebuggerAutoRecovery === true ? true : false;
 
         //prompt for host if not hardcoded
         if (config.host.trim() === '${promptForHost}') {
@@ -103,6 +103,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             } else {
                 await this.context.workspaceState.update('remoteHost', config.host);
             }
+            await this.context.workspaceState.update('enableDebuggerAutoRecovery', config.enableDebuggerAutoRecovery);
 
         }
         return config;
@@ -123,6 +124,6 @@ export interface BrightScriptDebugConfiguration extends DebugConfiguration {
     clearOutputOnLaunch: boolean;
     selectOutputOnLogMessage: boolean;
     enableVariablesPanel: boolean;
-    skipBogusBreakpoints: boolean;
+    enableDebuggerAutoRecovery: boolean;
     envFile?: string;
 }

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -29,6 +29,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
      * e.g. add all missing attributes to the debug configuration.
      */
     public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: BrightScriptDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
+        let settings: any = vscode.workspace.getConfiguration('brightscript') || {};
         //make sure we have an object
         config = config ? config : {} as any;
 
@@ -46,6 +47,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         config.clearOutputOnLaunch = config.clearOutputOnLaunch === true ? true : false;
         config.selectOutputOnLogMessage = config.selectOutputOnLogMessage === true ? true : false;
         config.enableVariablesPanel = 'enableVariablesPanel' in config ? config.enableVariablesPanel : true;
+        config.skipBogusBreakpoints = config.skipBogusBreakpoints === true ? true : (settings.debug || {}).skipBogusBreakpoints;
 
         //prompt for host if not hardcoded
         if (config.host.trim() === '${promptForHost}') {
@@ -121,5 +123,6 @@ export interface BrightScriptDebugConfiguration extends DebugConfiguration {
     clearOutputOnLaunch: boolean;
     selectOutputOnLogMessage: boolean;
     enableVariablesPanel: boolean;
+    skipBogusBreakpoints: boolean;
     envFile?: string;
 }

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -158,7 +158,7 @@ export class LogOutputManager {
         let lines = lineText.split('\n');
         lines.forEach((line) => {
             if (line !== '') {
-                if (!(this.config.output || {}).includeStackTracesInLogOutput) {
+                if (!(this.config.output || {}).includeStackTraces) {
                         // filter out debugger noise
                     if (line.match(this.debugStartRegex)) {
                         console.log('start MicroDebugger block');

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -158,7 +158,7 @@ export class LogOutputManager {
         let lines = lineText.split('\n');
         lines.forEach((line) => {
             if (line !== '') {
-                if ((this.config.output || {}).doNotIncludeStackTracesInLogOutput) {
+                if (!(this.config.output || {}).includeStackTracesInLogOutput) {
                         // filter out debugger noise
                     if (line.match(this.debugStartRegex)) {
                         console.log('start MicroDebugger block');

--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -33,7 +33,7 @@ export class RokuAdapter {
     private maxDataMsWhenCompiling: number;
     private compileErrorTimer: any;
     private isNextBreakpointSkipped: boolean = false;
-    private skipBogusBreakpoints: boolean;
+    private enableDebuggerAutoRecovery: boolean;
     private isInMicroDebugger: boolean;
     private debugStartRegex: RegExp;
     private debugEndRegex: RegExp;
@@ -142,7 +142,7 @@ export class RokuAdapter {
                 console.log('ended MicroDebugger block');
                 this.isInMicroDebugger = false;
             } else if (this.isInMicroDebugger) {
-                if (this.skipBogusBreakpoints && line.startsWith('Break in ')) {
+                if (this.enableDebuggerAutoRecovery && line.startsWith('Break in ')) {
                     console.log('this block is a break: skipping it');
                     this.isNextBreakpointSkipped = true;
                 }
@@ -154,9 +154,9 @@ export class RokuAdapter {
     /**
      * Connect to the telnet session. This should be called before the channel is launched.
      */
-    public async connect(skipBogusBreakpoints: boolean = false) {
+    public async connect(enableDebuggerAutoRecovery: boolean = false) {
         let deferred = defer();
-        this.skipBogusBreakpoints = skipBogusBreakpoints;
+        this.enableDebuggerAutoRecovery = enableDebuggerAutoRecovery;
         this.isInMicroDebugger = false;
         this.isNextBreakpointSkipped = false;
         try {

--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -19,6 +19,8 @@ export class RokuAdapter {
         this.compilingLines = [];
         this.lastUnhandledDataTime = 0;
         this.maxDataMsWhenCompiling = 500;
+        this.debugStartRegex = new RegExp('BrightScript Micro Debugger\.', 'ig');
+        this.debugEndRegex = new RegExp('Brightscript Debugger>', 'ig');
     }
 
     private status: RokuAdapterStatus;
@@ -30,6 +32,12 @@ export class RokuAdapter {
     private lastUnhandledDataTime: number;
     private maxDataMsWhenCompiling: number;
     private compileErrorTimer: any;
+    private isContinuedOnce: boolean;
+    private isNextBreakpointSkipped: boolean = false;
+    private isInMicroDebugger: boolean;
+    private currentMicroDebuggerText: string;
+    private debugStartRegex: RegExp;
+    private debugEndRegex: RegExp;
 
     private cache = {};
 
@@ -122,11 +130,43 @@ export class RokuAdapter {
         });
     }
 
+    public processBreakpoints(text): string | null {
+        // console.log(lines);
+        let newLines = eol.split(text);
+        newLines.forEach((line) => {
+            console.log('Running processing line; ', line);
+            if (line.match(this.debugStartRegex)) {
+                console.log('start MicroDebugger block');
+                this.isInMicroDebugger = true;
+                this.currentMicroDebuggerText = '';
+                this.isNextBreakpointSkipped = false;
+                text = 'Pausing for a breakpoint...';
+            } else if (this.isInMicroDebugger && line.match(this.debugEndRegex)) {
+                console.log('ended MicroDebugger block');
+                this.isInMicroDebugger = false;
+                if (this.isNextBreakpointSkipped) {
+                    text += '\n**Was a bogus breakpoint** Skipping!\n';
+                } else {
+                    text = null; //this.currentMicroDebuggerText;
+                }
+            } else if (this.isInMicroDebugger) {
+                this.currentMicroDebuggerText += line + '\n';
+                if (line.startsWith('Break in ')) {
+                    console.log('this block is a break: skipping it');
+                    this.isNextBreakpointSkipped = true;
+                }
+                text = null;
+            }
+        });
+        return text;
+    }
+
     /**
      * Connect to the telnet session. This should be called before the channel is launched.
      */
     public async connect() {
         let deferred = defer();
+
         try {
             //force roku to return to home screen. This gives the roku adapter some security in knowing new messages won't be appearing during initialization
             await rokuDeploy.pressHomeButton(this.host);
@@ -155,7 +195,10 @@ export class RokuAdapter {
 
             //forward all raw counsole output
             this.requestPipeline.on('console-output', (output) => {
-                this.emit('console-output', output);
+                const text = this.processBreakpoints(output);
+                if (text) {
+                    this.emit('console-output', text);
+                }
             });
 
             //listen for any console output that was not handled by other methods in the adapter
@@ -169,7 +212,10 @@ export class RokuAdapter {
                 }
 
                 //forward all unhandled console output
-                this.emit('unhandled-console-output', responseText);
+                const text = this.processBreakpoints(responseText);
+                if (text) {
+                    this.emit('unhandled-console-output', text);
+                }
 
                 this.processUnhandledLines(responseText);
                 let match;
@@ -189,11 +235,18 @@ export class RokuAdapter {
                     //watch for debugger prompt output
                     if (match = /Brightscript\s*Debugger>\s*$/i.exec(responseText.trim())) {
                         //if we are activated AND this is the first time seeing the debugger prompt since a continue/step action
-                        if (this.isActivated && this.isAtDebuggerPrompt === false) {
-                            this.isAtDebuggerPrompt = true;
-                            this.emit('suspend');
+                        if (this.isNextBreakpointSkipped) {
+                            console.log('this breakpoint is flagged to be skipped');
+                            this.isInMicroDebugger = false;
+                            this.isNextBreakpointSkipped = false;
+                            this.requestPipeline.executeCommand('c', false, false);
                         } else {
-                            this.isAtDebuggerPrompt = true;
+                            if (this.isActivated && this.isAtDebuggerPrompt === false) {
+                                this.isAtDebuggerPrompt = true;
+                                this.emit('suspend');
+                            } else {
+                                this.isAtDebuggerPrompt = true;
+                            }
                         }
                     } else {
                         this.isAtDebuggerPrompt = false;
@@ -525,6 +578,7 @@ export class RokuAdapter {
      */
     public continue() {
         this.clearCache();
+        this.isContinuedOnce = true;
         return this.requestPipeline.executeCommand('c', false);
     }
 
@@ -941,10 +995,12 @@ export class RequestPipeline {
     constructor(
         private client: Socket
     ) {
+        this.debuggerLineRegex = /Brightscript\s+Debugger>\s*$/i;
         this.connect();
     }
 
     private requests: RequestPipelineRequest[] = [];
+    private debuggerLineRegex: RegExp;
 
     private get isProcessing() {
         return this.currentRequest !== undefined;
@@ -980,7 +1036,7 @@ export class RequestPipeline {
             } else {
                 let match;
                 //if responseText produced a prompt, return the responseText
-                if (match = /Brightscript\s+Debugger>\s*$/i.exec(allResponseText.trim())) {
+                if (match = this.debuggerLineRegex.exec(allResponseText.trim())) {
                     //resolve the command's promise (if it cares)
                     this.currentRequest.onComplete(allResponseText);
                     allResponseText = '';
@@ -998,12 +1054,14 @@ export class RequestPipeline {
      * @param commandFunction
      * @param waitForPrompt - if true, the promise will wait until we find a prompt, and return all output in between. If false, the promise will immediately resolve
      */
-    public executeCommand(command: string, waitForPrompt: boolean) {
+    public executeCommand(command: string, waitForPrompt: boolean, silent: boolean = false) {
         console.debug(`Execute command (and ${waitForPrompt ? 'do' : 'do not'} wait for prompt):`, command);
         return new Promise<string>((resolve, reject) => {
             let executeCommand = () => {
                 let commandText = `${command}\r\n`;
-                this.emit('console-output', command);
+                if (!silent) {
+                    this.emit('console-output', command);
+                }
                 this.client.write(commandText);
             };
             this.requests.push({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.debug.onDidReceiveDebugSessionCustomEvent((e) => {
         if (e.event === 'BSLaunchStartEvent') {
             docLinkProvider.setLaunchConfig(e.body);
+            logOutputManager.setLaunchConfig(e.body);
         }
     });
 


### PR DESCRIPTION
guards against bogus breakpoints, by adding micro debugger awareness to adapter and log output manager.

bogus breakpoints result from `break in` style breakpoints.

Also adds additional settings `skipBogusBreakpoints` and `doNotIncludeStackTracesInLogOutput`, and wires them both into the log output and adapter so that they can be turned on/off

Tested both on and off for both flags, and observed no regressions in step debugging or breakpoint/resume and error stops

I can't guarantee this works in all cases : but I work with it on all the time now and the only issue I get is if I get impatient waiting for all the bogus breakpoints to pass, and hit another one.