### PR TITLE
Multiple source directory support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Here's a sample launch.json for this scenario:
             "host": "192.168.1.100",
             "password": "password",
             "rootDir": "${workspaceFolder}/dist",
-            "debugRootDir": "${workspaceFolder}/src",
+            "sourceDirs": ["${workspaceFolder}/src"],
             "preLaunchTask": "your-build-task-here"
         }
     ]

--- a/package.json
+++ b/package.json
@@ -138,12 +138,13 @@
                             },
                             "debugRootDir": {
                                 "type": "string",
-                                "description": "Depreciated, use sourceDirs, which is an array of source locations",
+                                "deprecationMessage":"Deprecated. Use sourceDirs instead",
+                                "description": "If you have a build system, rootDir will point to the build output folder, and this path should point to the actual source folder so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change line offsets between source files and built files, otherwise debugger lines will be out of sync.",
                                 "default": "${workspaceFolder}"
                             },
                             "sourceDirs": {
                                 "type": "array",
-                                "description": "If you have a build system, sourceDirs will point to the build output folder, and this path should point to the actual source folder so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change line offsets between source files and built files, otherwise debugger lines will be out of sync.",
+                                "description": "If you have a build system, this array will point to paths of actual source folders so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change line offsets between source files and built files, otherwise, debugger lines will be out of sync.",
                                 "default": ["${workspaceFolder}"]
                             },
                             "outDir": {

--- a/package.json
+++ b/package.json
@@ -138,8 +138,13 @@
                             },
                             "debugRootDir": {
                                 "type": "string",
-                                "description": "If you have a build system, rootDir will point to the build output folder, and this path should point to the actual source folder so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change line offsets between source files and built files, otherwise debugger lines will be out of sync.",
+                                "description": "Depreciated, use sourceDirs, which is an array of source locations",
                                 "default": "${workspaceFolder}"
+                            },
+                            "sourceDirs": {
+                                "type": "array",
+                                "description": "If you have a build system, sourceDirs will point to the build output folder, and this path should point to the actual source folder so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change line offsets between source files and built files, otherwise debugger lines will be out of sync.",
+                                "default": ["${workspaceFolder}"]
                             },
                             "outDir": {
                                 "type": "string",

--- a/src/BrightScriptDebugSession.spec.ts
+++ b/src/BrightScriptDebugSession.spec.ts
@@ -366,7 +366,7 @@ describe('Debugger', () => {
 
         it('remaps to debug folder when specified', () => {
             (session as any).launchArgs = {
-                debugRootDir: path.normalize('/src'),
+                sourceDirs: [path.normalize('/src')],
                 rootDir: path.normalize('/dest')
             };
             args.breakpoints = [{ line: 1 }];
@@ -374,7 +374,7 @@ describe('Debugger', () => {
             session.setBreakPointsRequest(<any>{}, args);
             expect((session as any).breakpointsByClientPath[path.normalize('/src/some/file.brs')]).not.to.be.undefined;
 
-            delete (session as any).launchArgs.debugRootDir;
+            delete (session as any).launchArgs.sourceDirs;
 
             session.setBreakPointsRequest(<any>{}, args);
             expect((session as any).breakpointsByClientPath[path.normalize('/dest/some/file.brs')]).not.to.be.undefined;

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -140,8 +140,10 @@ export class BrightScriptDebugSession extends DebugSession {
             this.loadStagingDirPaths(stagingFolder);
 
             //convert source breakpoint paths to build paths
-            if (this.launchArgs.debugRootDir) {
-                this.convertBreakpointPaths(this.launchArgs.debugRootDir, this.launchArgs.rootDir);
+            if (this.launchArgs.sourceDirs) {
+                for (const sourceDir of this.launchArgs.sourceDirs) {
+                    this.convertBreakpointPaths(sourceDir, this.launchArgs.rootDir);
+                }
             }
 
             //add breakpoint lines to source files and then publish
@@ -149,8 +151,10 @@ export class BrightScriptDebugSession extends DebugSession {
             await this.addBreakpointStatements(stagingFolder);
 
             //convert source breakpoint paths to build paths
-            if (this.launchArgs.debugRootDir) {
-                this.convertBreakpointPaths(this.launchArgs.rootDir, this.launchArgs.debugRootDir);
+            if (this.launchArgs.sourceDirs) {
+                for (const sourceDir of this.launchArgs.sourceDirs) {
+                    this.convertBreakpointPaths(this.launchArgs.rootDir, sourceDir);
+                }
             }
 
             //create zip package from staging folder
@@ -243,12 +247,15 @@ export class BrightScriptDebugSession extends DebugSession {
     }
 
     protected convertBreakpointPaths(fromRootPath: string, toRootPath: string) {
-        //convert paths to debugRootDir paths for any breakpoints set before this launch call
+        //convert paths to sourceDirs paths for any breakpoints set before this launch call
         if (fromRootPath) {
             for (let clientPath in this.breakpointsByClientPath) {
-                let debugClientPath = path.normalize(clientPath.replace(fromRootPath, toRootPath));
-                this.breakpointsByClientPath[debugClientPath] = this.breakpointsByClientPath[clientPath];
-                delete this.breakpointsByClientPath[clientPath];
+                if (clientPath.includes(fromRootPath)){
+                    let debugClientPath = path.normalize(clientPath.replace(fromRootPath, toRootPath));
+                    this.breakpointsByClientPath[debugClientPath] = this.breakpointsByClientPath[clientPath];
+                    delete this.breakpointsByClientPath[clientPath];
+                }
+
             }
         }
     }
@@ -259,9 +266,16 @@ export class BrightScriptDebugSession extends DebugSession {
 
     public setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments) {
         let clientPath = path.normalize(args.source.path);
-        //if we have a debugRootDir, convert the rootDir path to debugRootDir path
-        if (this.launchArgs && this.launchArgs.debugRootDir) {
-            clientPath = clientPath.replace(this.launchArgs.rootDir, this.launchArgs.debugRootDir);
+        //if we have a sourceDirs, convert the rootDir path to sourceDirs path
+        if (this.launchArgs && this.launchArgs.sourceDirs) {
+            let lastWorkingPath = ""
+            for (const sourceDir of this.launchArgs.sourceDirs) {
+                clientPath = clientPath.replace(this.launchArgs.rootDir, sourceDir);
+                if (fsExtra.pathExistsSync(clientPath)){
+                    lastWorkingPath = clientPath;
+                }
+            }
+            clientPath = lastWorkingPath;
         }
         let extension = path.extname(clientPath).toLowerCase();
 
@@ -550,11 +564,18 @@ export class BrightScriptDebugSession extends DebugSession {
                 //we found multiple files with the exact same path (unlikely)...nothing we can do about it.
             }
         }
-        //use debugRootDir if provided, or rootDir if not provided.
-        let rootDir = this.launchArgs.debugRootDir ? this.launchArgs.debugRootDir : this.launchArgs.rootDir;
+        let rootDir = this.launchArgs.sourceDirs ? this.launchArgs.sourceDirs : this.launchArgs.rootDir;
 
-        let clientPath = path.normalize(path.join(rootDir, debuggerPath));
-        return clientPath;
+        //use sourceDirs if provided, or rootDir if not provided.
+        let lastExistingPath = ""
+        for (const sourceDir of rootDir) {
+            let clientPath = path.normalize(path.join(sourceDir, debuggerPath));
+            if (fsExtra.pathExistsSync(clientPath))
+                lastExistingPath = clientPath;
+        }
+        return lastExistingPath;
+
+
     }
 
     /**
@@ -826,7 +847,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
      * so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change
      * line offsets between source files and built files, otherwise debugger lines will be out of sync.
      */
-    debugRootDir: string;
+    sourceDirs: string[];
     /**
      * The folder where the output files are places during the packaging process
      */

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -253,8 +253,9 @@ export class BrightScriptDebugSession extends DebugSession {
             for (let clientPath in this.breakpointsByClientPath) {
                 let included = false;
                 for (const fromRootPath of sourcePaths) {
-                    if (clientPath.includes(fromRootPath)){
+                    if (clientPath.includes(path.normalize(fromRootPath + path.sep))){
                         included = true
+                        break;
                     }
                 }
                 if (!included){
@@ -582,7 +583,7 @@ export class BrightScriptDebugSession extends DebugSession {
                 //we found multiple files with the exact same path (unlikely)...nothing we can do about it.
             }
         }
-        let rootDir = this.launchArgs.sourceDirs ? this.launchArgs.sourceDirs : this.launchArgs.rootDir;
+        let rootDir = this.launchArgs.sourceDirs ? this.launchArgs.sourceDirs : [this.launchArgs.rootDir];
 
         //use sourceDirs if provided, or rootDir if not provided.
         let lastExistingPath = ""
@@ -862,6 +863,13 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     rootDir: string;
     /**
      * If you have a build system, rootDir will point to the build output folder, and this path should point to the actual source folder
+     * so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change
+     * line offsets between source files and built files, otherwise debugger lines will be out of sync.
+     * @deprecated Use sourceDirs instead
+     */
+    debugRootDir: string;
+    /**
+     * If you have a build system, rootDir will point to the build output folder, and this path should point to the actual source folders
      * so that breakpoints can be set in the source files when debugging. In order for this to work, your build process cannot change
      * line offsets between source files and built files, otherwise debugger lines will be out of sync.
      */

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -31,6 +31,12 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: BrightScriptDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
         //make sure we have an object
         config = config ? config : {} as any;
+        
+        //Check for depreciated Items
+        if (config.debugRootDir){
+            throw new Error('Depreciated config value debugRootDir, use sourceDirs');
+        }
+
 
         config.type = config.type ? config.type : 'brightscript';
         config.name = config.name ? config.name : 'BrightScript Debug: Launch';

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -31,12 +31,15 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: BrightScriptDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
         //make sure we have an object
         config = config ? config : {} as any;
-        
-        //Check for depreciated Items
-        if (config.debugRootDir){
-            throw new Error('Depreciated config value debugRootDir, use sourceDirs');
-        }
 
+        //Check for depreciated Items
+        if(config.debugRootDir){
+            if(config.sourceDirs){
+                throw new Error("Cannot set both debugRootDir AND sourceDirs");
+            } else{
+                config.sourceDirs = [config.debugRootDir];
+            }
+        }
 
         config.type = config.type ? config.type : 'brightscript';
         config.name = config.name ? config.name : 'BrightScript Debug: Launch';

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -111,7 +111,7 @@ export interface BrightScriptDebugConfiguration extends DebugConfiguration {
     host: string;
     password: string;
     rootDir: string;
-    debugRootDir?: string;
+    sourceDirs?: string[];
     outDir: string;
     stopOnEntry: boolean;
     files?: FilesType[];

--- a/src/LogDocumentLinkProvider.ts
+++ b/src/LogDocumentLinkProvider.ts
@@ -20,7 +20,7 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
         this.launchConfig = launchConfig;
         this.fileMaps = {};
 
-        let sourceRootDir = launchConfig.sourceDirs ? launchConfig.sourceDirs : launchConfig.rootDir;
+        let sourceRootDir = launchConfig.sourceDirs ? launchConfig.sourceDirs : [launchConfig.rootDir];
         let paths = [];
         for (const rootDir of sourceRootDir) {
             let pathsFromRoot = await this.rokuDeploy.getFilePaths(launchConfig.files, launchConfig.outDir, rootDir);

--- a/src/LogDocumentLinkProvider.ts
+++ b/src/LogDocumentLinkProvider.ts
@@ -20,10 +20,13 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
         this.launchConfig = launchConfig;
         this.fileMaps = {};
 
-        let sourceRootDir = launchConfig.debugRootDir ? launchConfig.debugRootDir : launchConfig.rootDir;
-
+        let sourceRootDir = launchConfig.sourceDirs ? launchConfig.sourceDirs : launchConfig.rootDir;
+        let paths = [];
+        for (const rootDir of sourceRootDir) {
+            let pathsFromRoot = await this.rokuDeploy.getFilePaths(launchConfig.files, launchConfig.outDir, rootDir);
+            paths = paths.concat(pathsFromRoot)
+        }
         //get every file used in this project
-        let paths = await this.rokuDeploy.getFilePaths(launchConfig.files, launchConfig.outDir, sourceRootDir);
 
         let outDir = path.normalize(launchConfig.outDir);
 


### PR DESCRIPTION
Multiple source directory support 
- Depreciates debugrootDir string and replaces it with sourceDirs array to support multiple source directories. 
- Fires error when debugrootDir is used in the launch and prompts the user to update to sourceDirs.
- Removed all remaining breakpoints after looping through them to prevent crash on a breakpoint existing in the workspace but out of scope