### PR TITLE
High level objects not always parsed correctly

### DIFF
--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -812,7 +812,7 @@ export class RokuAdapter {
                     return children;
                 }
                 let match;
-                match = /(\w+):(.+)/i.exec(line);
+                match = /(\S+[^:]):(.+)/i.exec(line);
                 let name = match[1].trim();
                 let value = match[2].trim();
 

--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -644,7 +644,7 @@ export class RokuAdapter {
      * @param value
      */
     private getExpressionDetails(value: string) {
-        return new RegExp(/([\s|\S]+?)(?:\r|\r\n)+brightscript debugger>/i).exec(value);
+        return /([\s|\S]+?)(?:\r|\r\n)+brightscript debugger>/i.exec(value);
     }
 
     /**
@@ -652,7 +652,7 @@ export class RokuAdapter {
      * @param value
      */
     private getHighLevelTypeDetails(value: string) {
-        return new RegExp(/<.*:\s*(\w+\s*\:*\s*[\w\.]*)>/gi).exec(value);
+        return /<.*:\s*(\w+\s*\:*\s*[\w\.]*)>/gi.exec(value);
     }
 
     /**
@@ -660,7 +660,7 @@ export class RokuAdapter {
      * @param value
      */
     private getFirstWord(value: string) {
-        return new RegExp(/^([\w.\-=]*)\s/).exec(value);
+        return /^([\w.\-=]*)\s/.exec(value);
     }
 
     /**

--- a/src/RokuAdapter.ts
+++ b/src/RokuAdapter.ts
@@ -640,7 +640,7 @@ export class RokuAdapter {
     }
 
     /**
-     *
+     * Runs a regex to get the content between telnet commands
      * @param value
      */
     private getExpressionDetails(value: string) {


### PR DESCRIPTION
This was related to using `exec` with a `g` flag. See the following from the docs:

If your regular expression uses the "g" flag, you can use the exec() method multiple times to find successive matches in the same string. When you do so, the search starts at the substring of str specified by the regular expression's lastIndex property (test() will also advance the lastIndex property).  Note that the lastIndex property will not be reset when searching a different string it will start its search at its existing lastIndex .