### PR TITLE
resets microdebugger and next breakpoint flags

### DIFF
--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -105,6 +105,8 @@ export class LogOutputManager {
     private debugEndRegex: RegExp;
 
     public onDidStartDebugSession() {
+        this.isInMicroDebugger = false;
+        this.isNextBreakpointSkipped = false;
         if (this.isClearingOutputOnLaunch) {
             this.clearOutput();
         }
@@ -119,6 +121,8 @@ export class LogOutputManager {
         if (e.event === 'BSLogOutputEvent') {
             this.appendLine(e.body);
         } else if (e.event === 'BSLaunchStartEvent') {
+            this.isInMicroDebugger = false;
+            this.isNextBreakpointSkipped = false;
             if (this.isFocusingOutputOnLaunch) {
                 vscode.commands.executeCommand('workbench.action.focusPanel');
             }


### PR DESCRIPTION
If a breakpoint is hit - and the app stops (e.g. a runtime error, or breakpoint then app quit), and breakpoint continuation is enabled, then in most cases, logoutput will stop making it's way to the brightscript log.

This pr fixes that problem; by resetting these flags on launch.