### PR TITLE
Tracker task injection on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,20 +270,20 @@ There are several string placeholders you can use when defining your deep link u
 
 ## RALE Support
 You can also have the extension automatically inject the `TrackerTack.xml` and the code snippet required to start the tracker task.
-Do do this you need a few simple things:
+To do this you need a few simple things:
 - In your VS Code user settings add the `brightscript.rokuAdvancedLayoutEditor.trackerTaskFileLocation` setting. (See [Extension Settings](#Extension-Settings) for more information)
-- Add the entry point comment `' vs_code_tracker_entry` to your code.
+- Add the entry point comment `' vscode_rale_tracker_entry` to your code.
   - This is optional as you can still include the the code to create the tracker task your self.
-  - I recommend adding it to the end of your `screen.show()` call. For example: `screen.show() ' vs_code_tracker_entry`
+  - I recommend adding it to the end of your `screen.show()` call. For example: `screen.show() ' vscode_rale_tracker_entry`
   - This can be added anywhere in the channel including source files but it must be on or after the your call to `screen.show()`
-- Set the `injectTrackerTask` value to true in your `launch.json`. For example:
+- Set the `injectRaleTrackerTask` value to true in your `launch.json`. For example:
 
 ```json
 {
     "type": "brightscript",
     "rootDir": "${workspaceFolder}/dist",
     "host": "192.168.1.2",
-    "injectTrackerTask": true
+    "injectRaleTrackerTask": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A VSCode extension to support Roku's BrightScript language.
   - logpoints
   - hit count breakpoints
 - Automatic Rendezvous tracking when `logrendezvous` is enabled on the Roku. See [here](https://developer.roku.com/docs/developer-program/debugging/debugging-channels.md#scenegraph-debug-server-port-8080-commands) for information on how to enable rendezvous logging your Roku.
+- Injection of the Roku Advanced Layout Editor(RALE) task from a single user managed version
+  - This helps avoid committing the tracker to you repo and also lets you manage what version you want installed rather then other users on the project
+  - See ([Extension Settings](#Extension-Settings) and [RALE Support](#RALE-Support) for more information)
 - Publish directly to a roku device from VSCode (provided by [roku-deploy](https://github.com/TwitchBronBron/roku-deploy))
   - Also supports zip'ing and static file hosting for Component Libraries ([click here](#Component-Libraries) for more information)
 - Basic symbol navigation for document and workspace ("APPLE/Ctrl + SHIFT + O" for document, "APPLE/Ctrl + T" for workspace)
@@ -265,6 +268,24 @@ There are several string placeholders you can use when defining your deep link u
 
  - `${promptForDeepLinkUrl}` - if the entire `deepLinkUrl` is set to this, then at debug launch time, an input box will appear asking you to input the full deep link url.
 
+## RALE Support
+You can also have the extension automatically inject the `TrackerTack.xml` and the code snippet required to start the tracker task.
+Do do this you need a few simple things:
+- In your VS Code user settings add the `brightscript.rokuAdvancedLayoutEditor.trackerTaskFileLocation` setting. (See [Extension Settings](#Extension-Settings) for more information)
+- Add the entry point comment `' vs_code_tracker_entry` to your code.
+  - This is optional as you can still include the the code to create the tracker task your self.
+  - I recommend adding it to the end of your `screen.show()` call. For example: `screen.show() ' vs_code_tracker_entry`
+  - This can be added anywhere in the channel including source files but it must be on or after the your call to `screen.show()`
+- Set the `injectTrackerTask` value to true in your `launch.json`. For example:
+
+```json
+{
+    "type": "brightscript",
+    "rootDir": "${workspaceFolder}/dist",
+    "host": "192.168.1.2",
+    "injectTrackerTask": true
+}
+```
 
 ## Extension Settings
 
@@ -283,6 +304,7 @@ This extension contributes the following settings:
 * `brightscript.output.hyperlinkFormat`: specifies the display format for log output `pkg` link
 * `brightscript.deviceDiscovery.showInfoMessages`: If set to true, an info toast will be shown when a Roku device has been found on the network.
 * `brightscript.deviceDiscovery.enabled`: If set to true, the extension will automatically watch and scan the network for online Roku devices. This can be pared with the `${promptForHost}` option in the launch config to display a list of online Rokus, removing the need to constantly change the host IP in your config files.
+* `brightscript.rokuAdvancedLayoutEditor.trackerTaskFileLocation`: This is an absolute path to the TrackerTask.xml file to be injected into your Roku channel during a debug session. (i.e. `/Users/user/roku/TrackerTask/TrackerTask.xml`)
 
 ## Roku Remote Control
 

--- a/package.json
+++ b/package.json
@@ -319,9 +319,9 @@
                                     "normal"
                                 ]
                             },
-                            "injectTrackerTask": {
+                            "injectRaleTrackerTask": {
                                 "type": "boolean",
-                                "description": "Will inject the TrackerTask into your channel if one is defined in your user settings.",
+                                "description": "Will inject the Roku Advanced Layout Editor(RALE) TrackerTask into your channel if one is defined in your user settings.",
                                 "default": false
                             },
                             "files": {

--- a/package.json
+++ b/package.json
@@ -319,6 +319,11 @@
                                     "normal"
                                 ]
                             },
+                            "injectTrackerTask": {
+                                "type": "boolean",
+                                "description": "Will inject the TrackerTask into your channel if one is defined in your user settings.",
+                                "default": false
+                            },
                             "files": {
                                 "type": "array",
                                 "description": "An array of file paths, file globs, or {src:string;dest:string} objects that will be copied into the deployment package. This will override the defaults, so if specified, you must provide ALL files. See https://npmjs.com/roku-deploy for examples.",
@@ -589,6 +594,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "If set to true, the extension will automatically watch and scan the network for online Roku devices. This can be pared with the ${promptForHost} option in the launch config to display a list of online Rokus, removing the need to constantly change the host IP in your config files.",
+                    "scope": "resource"
+                },
+                "brightscript.rokuAdvancedLayoutEditor.trackerTaskFileLocation": {
+                    "type": "string",
+                    "description": "This is an absolute path to the TrackerTask.xml file to be injected into your Roku channel during a debug session.",
                     "scope": "resource"
                 }
             }

--- a/src/BrightScriptDebugSession.spec.ts
+++ b/src/BrightScriptDebugSession.spec.ts
@@ -439,7 +439,7 @@ describe('Debugger', () => {
 
         beforeEach(() => {
             key = 'vscode_rale_tracker_entry';
-            trackerTaskCode = `if true = CreateObject("roAppInfo").IsDev() then m.vs_code_tracker_task = createObject("roSGNode", "TrackerTask") ' Roku Advanced Layout Editor Support`;
+            trackerTaskCode = `if true = CreateObject("roAppInfo").IsDev() then m.vscode_rale_tracker_task = createObject("roSGNode", "TrackerTask") ' Roku Advanced Layout Editor Support`;
         });
 
         afterEach(() => {

--- a/src/BrightScriptDebugSession.spec.ts
+++ b/src/BrightScriptDebugSession.spec.ts
@@ -432,13 +432,13 @@ describe('Debugger', () => {
         });
     });
 
-    describe('injectTrackerTaskCode', () => {
+    describe('injectRaleTrackerTaskCode', () => {
         let key: string;
         let trackerTaskCode: string;
         let folder;
 
         beforeEach(() => {
-            key = 'vs_code_tracker_entry';
+            key = 'vscode_rale_tracker_entry';
             trackerTaskCode = `if true = CreateObject("roAppInfo").IsDev() then m.vs_code_tracker_task = createObject("roSGNode", "TrackerTask") ' Roku Advanced Layout Editor Support`;
         });
 
@@ -455,7 +455,7 @@ describe('Debugger', () => {
             let filePath = path.resolve(`${folder}/main.${fileExt}`);
 
             fsExtra.writeFileSync(filePath, fileContents);
-            await session.injectTrackerTaskCode(folder);
+            await session.injectRaleTrackerTaskCode(folder);
             let newFileContents = (await fsExtra.readFile(filePath)).toString();
             expect(newFileContents).to.equal(expectedContents);
         }

--- a/src/BrightScriptDebugSession.spec.ts
+++ b/src/BrightScriptDebugSession.spec.ts
@@ -399,6 +399,7 @@ describe('Debugger', () => {
             await doTest('\n\nsub   RunUserInterface()\nend sub', 'sub   RunUserInterface()', 3);
             await doTest('\n\nsub RunUserInterface   ()\nend sub', 'sub RunUserInterface   ()', 3);
         });
+
         it('works for sub main', async () => {
             await doTest('\nsub Main()\nend sub', 'sub Main()', 2);
             //works with args
@@ -414,6 +415,20 @@ describe('Debugger', () => {
             //works with extra spacing
             await doTest('function   Main()\nend function', 'function   Main()', 1);
             await doTest('function Main   ()\nend function', 'function Main   ()', 1);
+        });
+
+        it('works for sub RunScreenSaver', async () => {
+            await doTest('sub RunScreenSaver()\nend sub', 'sub RunScreenSaver()', 1);
+            //works with extra spacing
+            await doTest('sub   RunScreenSaver()\nend sub', 'sub   RunScreenSaver()', 1);
+            await doTest('sub RunScreenSaver   ()\nend sub', 'sub RunScreenSaver   ()', 1);
+        });
+
+        it('works for function RunScreenSaver', async () => {
+            await doTest('function RunScreenSaver()\nend function', 'function RunScreenSaver()', 1);
+            //works with extra spacing
+            await doTest('function   RunScreenSaver()\nend function', 'function   RunScreenSaver()', 1);
+            await doTest('function RunScreenSaver   ()\nend function', 'function RunScreenSaver   ()', 1);
         });
     });
 

--- a/src/BrightScriptDebugSession.spec.ts
+++ b/src/BrightScriptDebugSession.spec.ts
@@ -454,20 +454,7 @@ describe('Debugger', () => {
 
             let filePath = path.resolve(`${folder}/main.${fileExt}`);
 
-            //prevent actually talking to the file system...just hardcode the list to exactly our main file
-            (session.rokuDeploy as any).getFilePaths = function() {
-                return [{
-                    src: filePath,
-                    dest: filePath
-                }];
-            };
-
             fsExtra.writeFileSync(filePath, fileContents);
-            (session as any).launchArgs = {
-                files: [
-                    folder + '/**/*'
-                ]
-            };
             await session.injectTrackerTaskCode(folder);
             let newFileContents = (await fsExtra.readFile(filePath)).toString();
             expect(newFileContents).to.equal(expectedContents);

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -196,11 +196,11 @@ export class BrightScriptDebugSession extends DebugSession {
             }
 
             // inject the tracker task into the staging files if we have everything we need
-            if (this.launchArgs.injectTrackerTask && this.launchArgs.trackerTaskFileLocation) {
+            if (this.launchArgs.injectRaleTrackerTask && this.launchArgs.trackerTaskFileLocation) {
                 try {
                     await fsExtra.copy(this.launchArgs.trackerTaskFileLocation, path.join(this.stagingPath + '/components/', 'TrackerTask.xml'));
                     console.log('TrackerTask successfully injected');
-                    await this.injectTrackerTaskCode(this.stagingPath);
+                    await this.injectRaleTrackerTaskCode(this.stagingPath);
                 } catch (err) {
                     console.error(err);
                 }
@@ -1113,12 +1113,12 @@ export class BrightScriptDebugSession extends DebugSession {
     }
 
     /**
-     * Will search the project files for the comment "\' vs_code_tracker_entry" and replace it with the code needed to start the TrackerTask.
+     * Will search the project files for the comment "' vscode_rale_tracker_entry" and replace it with the code needed to start the TrackerTask.
      * @param stagingPath
      */
-    public async injectTrackerTaskCode(stagingPath: string) {
+    public async injectRaleTrackerTaskCode(stagingPath: string) {
         // Search for the tracker task entry injection point
-        let trackerEntryTerm = `('\\s*vs_code_tracker_entry[^\\S\\r\\n]*)`;
+        let trackerEntryTerm = `('\\s*vscode_rale_tracker_entry[^\\S\\r\\n]*)`;
         let results = Object.assign(
             {},
             await findInFiles.find({ term: trackerEntryTerm, flags: 'ig' }, stagingPath, /.*\.brs/),
@@ -1130,7 +1130,7 @@ export class BrightScriptDebugSession extends DebugSession {
             // Do not throw an error as we don't want to prevent the user from launching the channel
             // just because they don't have a local version of the TrackerTask.
             this.sendDebugLogLine('WARNING: Unable to find an entry point for Tracker Task.');
-            this.sendDebugLogLine('Please make sure that you have the following comment in your BrightScript project: "\' vs_code_tracker_entry"');
+            this.sendDebugLogLine('Please make sure that you have the following comment in your BrightScript project: "\' vscode_rale_tracker_entry"');
         } else {
             // This code will start the tracker task in the project
             let trackerTaskSupportCode = `if true = CreateObject("roAppInfo").IsDev() then m.vs_code_tracker_task = createObject("roSGNode", "TrackerTask") ' Roku Advanced Layout Editor Support`;
@@ -1449,9 +1449,9 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     enableLookupVariableNodeChildren: boolean;
 
     /**
-     * Will inject the TrackerTask into your channel if one is defined in your user settings.
+     * Will inject the Roku Advanced Layout Editor(RALE) TrackerTask into your channel if one is defined in your user settings.
      */
-    injectTrackerTask: boolean;
+    injectRaleTrackerTask: boolean;
     /**
      * This is an absolute path to the TrackerTask.xml file to be injected into your Roku channel during a debug session.
      */

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -1146,10 +1146,10 @@ export class BrightScriptDebugSession extends DebugSession {
                     // Remove the comment part of the match from the line to use as a base for the new line
                     let newLine = line.replace(fileResults.matches[index], '');
                     let match;
-                    if (match = /[\S]/.exec(line)) {
+                    if (match = /[\S]/.exec(newLine)) {
                         // There was some form of code before the comment the was removed
                         // append and use single line syntax
-                        newLine += ` : ${trackerTaskSupportCode}`;
+                        newLine += `: ${trackerTaskSupportCode}`;
                     } else {
                         newLine += trackerTaskSupportCode;
                     }

--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -1133,7 +1133,7 @@ export class BrightScriptDebugSession extends DebugSession {
             this.sendDebugLogLine('Please make sure that you have the following comment in your BrightScript project: "\' vscode_rale_tracker_entry"');
         } else {
             // This code will start the tracker task in the project
-            let trackerTaskSupportCode = `if true = CreateObject("roAppInfo").IsDev() then m.vs_code_tracker_task = createObject("roSGNode", "TrackerTask") ' Roku Advanced Layout Editor Support`;
+            let trackerTaskSupportCode = `if true = CreateObject("roAppInfo").IsDev() then m.vscode_rale_tracker_task = createObject("roSGNode", "TrackerTask") ' Roku Advanced Layout Editor Support`;
 
             // process the entry points found in the files
             // unlikely but we might have more then one

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -100,7 +100,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         config.stopOnEntry = config.stopOnEntry ? config.stopOnEntry : false;
         config.outDir = this.util.checkForTrailingSlash(config.outDir ? config.outDir : '${workspaceFolder}/out');
         config.retainDeploymentArchive = config.retainDeploymentArchive === false ? false : true;
-        config.injectTrackerTask = config.injectTrackerTask === false ? false : true;
+        config.injectRaleTrackerTask = config.injectRaleTrackerTask === false ? false : true;
         config.retainStagingFolder = config.retainStagingFolder === true ? true : false;
         config.clearOutputOnLaunch = config.clearOutputOnLaunch === true ? true : false;
         config.selectOutputOnLogMessage = config.selectOutputOnLogMessage === true ? true : false;
@@ -110,9 +110,9 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         config.enableLookupVariableNodeChildren = config.enableLookupVariableNodeChildren === true ? true : false;
         config.files = config.files ? config.files : defaultFilesArray;
 
-        if (config.injectTrackerTask) {
+        if (config.injectRaleTrackerTask) {
             if (await this.util.fileExists(this.trackerTaskFileLocation) === false) {
-                vscode.window.showErrorMessage(`InjectTrackerTask was set to true but could not find TrackerTask.xml at:\n${this.trackerTaskFileLocation}`);
+                vscode.window.showErrorMessage(`injectRaleTrackerTask was set to true but could not find TrackerTask.xml at:\n${this.trackerTaskFileLocation}`);
             } else {
                 config.trackerTaskFileLocation = this.trackerTaskFileLocation;
             }
@@ -265,7 +265,7 @@ export interface BrightScriptDebugConfiguration extends DebugConfiguration {
     files?: FilesType[];
     consoleOutput: 'full' | 'normal';
     retainDeploymentArchive: boolean;
-    injectTrackerTask: boolean;
+    injectRaleTrackerTask: boolean;
     trackerTaskFileLocation: string;
     retainStagingFolder: boolean;
     clearOutputOnLaunch: boolean;

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -68,6 +68,9 @@ export let vscode = {
             };
         },
         registerTreeDataProvider: function(viewId: string, treeDataProvider: TreeDataProvider<any>) {},
+        showErrorMessage: function(message: string) {
+
+        },
         activeTextEditor: {
             document: undefined
         }

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -15,6 +15,9 @@
             "include": "#end_region_comment"
         },
         {
+            "include": "#vscode_rale_tracker_entry_comment"
+        },
+        {
             "include": "#identifiers_with_type_designators"
         },
         {
@@ -275,6 +278,10 @@
         "end_region_comment": {
             "match": "^(i?\\s*'\\s*#endregion(\\s*.*)?$)",
             "name": "keyword.preprocessor.region.brs"
+        },
+        "vscode_rale_tracker_entry_comment": {
+            "match": "('\\s*vscode_rale_tracker_entry[^\\S\\r\\n]*)",
+            "name": "keyword.preprocessor.brs"
         }
     }
 }


### PR DESCRIPTION
The goal of this PR is to allow users to manage their version of the tracker task across all channels. This way the tracker task code is not committed to their channel repo and so that when the tracker task and desktop RALE app is updated they only need to update it in the one location.